### PR TITLE
BUG: fix upper, lower boundary typo

### DIFF
--- a/lcls-plc-tmo-optics/tmo_optics/POUs/P_StripeProtections.TcPOU
+++ b/lcls-plc-tmo-optics/tmo_optics/POUs/P_StripeProtections.TcPOU
@@ -42,10 +42,10 @@ Silicon surface: RBV <= 4820000: 0000_0000_0001_1110 (allow everything between 2
 	fbStripProtMR3K4 : FB_MirrorTwoCoatingProtection := (
 		sDevName := 'MR3K4',
 		nUpperCoatingBoundary := 5620000,
-		nLowerCoatingBitMask := F_eVExcludeRange(0, 350) AND F_eVExcludeRange(2.3E3, 7E3),
+		nUpperCoatingBitMask := F_eVExcludeRange(0, 350) AND F_eVExcludeRange(2.3E3, 7E3),
 		sUpperCoatingType := 'B4C',
 		nLowerCoatingBoundary := 4820000,
-		nUpperCoatingBitmask := F_eVExcludeRange(1.5E3, 7E3) AND F_eVExcludeRange(480, 680),
+		nLowerCoatingBitmask := F_eVExcludeRange(1.5E3, 7E3) AND F_eVExcludeRange(480, 680),
 		sLowerCoatingType := 'Si');		
 		
 END_VAR


### PR DESCRIPTION
There is a typo in the PMPS coating protection for MR3K4, in the file lcls-plc-tmo-optics/tmo_optics/POUs/P_StripeProtections.TcPOU. In line 45, Lower should be changed to Upper, and in line 48, Upper should be changed to Lower. Until this is changed the fast fault must be bypassed in order to allow TMO operation below 350 eV.