### PR TITLE
ENH: add temp faulting for mr2/3k4

### DIFF
--- a/lcls-plc-tmo-optics/_Config/PLC/tmo_optics.xti
+++ b/lcls-plc-tmo-optics/_Config/PLC/tmo_optics.xti
@@ -847,43 +847,6 @@ External Setpoint Generation:
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{8F4975B4-B3D9-9C2F-B09A-E19B3FB61C15}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_EL5042_Status</Name>
-			<BitSize>0</BitSize>
-			<BaseType GUID="{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}"/>
-		</DataType>
-		<DataType>
-			<Name GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
-			<Comment><![CDATA[ Renishaw BiSS-C absolute encoder used with an EL5042]]></Comment>
-			<BitSize>128</BitSize>
-			<SubItem>
-				<Name>Count</Name>
-				<Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
-				<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-				<BitSize>64</BitSize>
-				<BitOffs>0</BitOffs>
-				<Properties>
-					<Property>
-						<Name>TcAddressType</Name>
-						<Value>Input</Value>
-					</Property>
-				</Properties>
-			</SubItem>
-			<SubItem>
-				<Name>Status</Name>
-				<Type GUID="{8F4975B4-B3D9-9C2F-B09A-E19B3FB61C15}" Namespace="lcls_twincat_motion">ST_EL5042_Status</Type>
-				<Comment><![CDATA[ Status struct placeholder]]></Comment>
-				<BitSize>0</BitSize>
-				<BitOffs>64</BitOffs>
-			</SubItem>
-			<SubItem>
-				<Name>Ref</Name>
-				<Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
-				<Comment><![CDATA[ Encoder zero position (useful for aligned position with gantries)]]></Comment>
-				<BitSize>64</BitSize>
-				<BitOffs>64</BitOffs>
-			</SubItem>
-		</DataType>
-		<DataType>
 			<Name GUID="{7E016B85-166E-4B4F-AAC4-ECA8DDD44F13}">ST_PMPS_Attenuator_IO</Name>
 			<BitSize>64</BitSize>
 			<SubItem>
@@ -1161,6 +1124,43 @@ External Setpoint Generation:
 			</Hides>
 		</DataType>
 		<DataType>
+			<Name GUID="{8F4975B4-B3D9-9C2F-B09A-E19B3FB61C15}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_EL5042_Status</Name>
+			<BitSize>0</BitSize>
+			<BaseType GUID="{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}"/>
+		</DataType>
+		<DataType>
+			<Name GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
+			<Comment><![CDATA[ Renishaw BiSS-C absolute encoder used with an EL5042]]></Comment>
+			<BitSize>128</BitSize>
+			<SubItem>
+				<Name>Count</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
+				<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+				<BitSize>64</BitSize>
+				<BitOffs>0</BitOffs>
+				<Properties>
+					<Property>
+						<Name>TcAddressType</Name>
+						<Value>Input</Value>
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>Status</Name>
+				<Type GUID="{8F4975B4-B3D9-9C2F-B09A-E19B3FB61C15}" Namespace="lcls_twincat_motion">ST_EL5042_Status</Type>
+				<Comment><![CDATA[ Status struct placeholder]]></Comment>
+				<BitSize>0</BitSize>
+				<BitOffs>64</BitOffs>
+			</SubItem>
+			<SubItem>
+				<Name>Ref</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
+				<Comment><![CDATA[ Encoder zero position (useful for aligned position with gantries)]]></Comment>
+				<BitSize>64</BitSize>
+				<BitOffs>64</BitOffs>
+			</SubItem>
+		</DataType>
+		<DataType>
 			<Name GUID="{875D2B22-B7EB-497E-B933-0C004593CCF3}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">PLCTONC_AXIS_REF_CTRL</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{7FA5AD82-8B94-448C-8921-86A608467E2A}" Name="tmo_optics" PrjFilePath="..\..\tmo_optics\tmo_optics.plcproj" TmcFilePath="..\..\tmo_optics\tmo_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_optics\tmo_optics.tmc" TmcHash="{98D8E40B-E062-6F2F-8E5B-11A930123EFC}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_optics\tmo_optics.tmc" TmcHash="{81FA48AF-9C07-B957-924C-934A08B8467F}">
 			<Name>tmo_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -1370,11 +1370,6 @@ External Setpoint Generation:
 			</Vars>
 			<Vars VarGrpType="1" ContextId="2" AreaNo="32">
 				<Name>PlcTask Inputs</Name>
-				<Var>
-					<Name>lcls_twincat_optics_nrw.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
-					<Comment><![CDATA[Raw encoder count]]></Comment>
-					<Type>LINT</Type>
-				</Var>
 				<Var>
 					<Name>Main.M1.Axis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
@@ -1589,52 +1584,6 @@ External Setpoint Generation:
 				<Var>
 					<Name>Main.fbMotionStage_m5.fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				</Var>
-				<Var>
-					<Name>Main.M1K4.fbRunHOMS.bSTOEnable1</Name>
-					<Comment><![CDATA[ STO Button]]></Comment>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>Main.M1K4.fbRunHOMS.bSTOEnable2</Name>
-					<Type>BOOL</Type>
-				</Var>
-				<Var>
-					<Name>Main.M1K4.fbRunHOMS.stYupEnc</Name>
-					<Comment><![CDATA[ Encoders]]></Comment>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>Main.M1K4.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>Main.M1K4.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>Main.M1K4.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-				</Var>
-				<Var>
-					<Name>Main.M1K4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>Main.M1K4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>Main.M1K4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
-				</Var>
-				<Var>
-					<Name>Main.M1K4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
-					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.bDreamEnable1</Name>
@@ -2494,6 +2443,67 @@ External Setpoint Generation:
 					<Type>BIT</Type>
 				</Var>
 				<Var>
+					<Name>GVL_M2K4_RTD.nM2K4US_RTD_1</Name>
+					<Comment><![CDATA[ M2K4 BENDER RTDs
+ M2K4 US RTDs]]></Comment>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_M2K4_RTD.nM2K4US_RTD_2</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
+					<Type>LINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.M1K4.fbRunHOMS.bSTOEnable1</Name>
+					<Comment><![CDATA[ STO Button]]></Comment>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>Main.M1K4.fbRunHOMS.bSTOEnable2</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>Main.M1K4.fbRunHOMS.stYupEnc</Name>
+					<Comment><![CDATA[ Encoders]]></Comment>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>Main.M1K4.fbRunHOMS.stYdwnEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>Main.M1K4.fbRunHOMS.stXupEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>Main.M1K4.fbRunHOMS.stXdwnEnc</Name>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+				</Var>
+				<Var>
+					<Name>Main.M1K4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.M1K4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.M1K4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
+					<Name>Main.M1K4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
+					<Type>ULINT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_MR1K4_SOMS.fbCoolingPanel.fbFlow_1.iRaw</Name>
 					<Comment><![CDATA[ Connect this input to the terminal]]></Comment>
 					<Type>INT</Type>
@@ -2549,14 +2559,9 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_M2K4_RTD.nM2K4US_RTD_1</Name>
-					<Comment><![CDATA[ M2K4 BENDER RTDs
- M2K4 US RTDs]]></Comment>
-					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M2K4_RTD.nM2K4US_RTD_2</Name>
-					<Type>INT</Type>
+					<Name>GVL_M1K4.M1K4_Pitch.diEncCnt</Name>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
+					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_M2K4_RTD.nM2K4US_RTD_3</Name>
@@ -2566,11 +2571,6 @@ External Setpoint Generation:
 					<Name>GVL_M2K4_RTD.nM2K4DS_RTD_1</Name>
 					<Comment><![CDATA[ M2K4 DS RTDs]]></Comment>
 					<Type>INT</Type>
-				</Var>
-				<Var>
-					<Name>GVL_M1K4.M1K4_Pitch.diEncCnt</Name>
-					<Comment><![CDATA[Raw encoder count]]></Comment>
-					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_M2K4_RTD.nM2K4DS_RTD_2</Name>
@@ -3494,13 +3494,25 @@ External Setpoint Generation:
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^Term 40 (EK1100)^EL3202-0010_M2K4DS2_M2K4DS3">
 				<Link VarA="PlcTask Inputs^GVL_M2K4_RTD.nM2K4DS_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_M2K4_RTD.nM2K4DS_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^Term 40 (EK1100)^EL3202-0010_M2K4US1_M2K4US2">
 				<Link VarA="PlcTask Inputs^GVL_M2K4_RTD.nM2K4US_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_M2K4_RTD.nM2K4US_RTD_2" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^Term 40 (EK1100)^EL3202-0010_M2K4US3_M2K4DS1">
@@ -3510,13 +3522,25 @@ External Setpoint Generation:
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^Term 40 (EK1100)^EL3202-0010_M3K4DS2_M3K4DS3">
 				<Link VarA="PlcTask Inputs^GVL_M3K4_RTD.nM3K4DS_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_M3K4_RTD.nM3K4DS_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.bError" VarB="RTD Inputs Channel 1^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.bOverrange" VarB="RTD Inputs Channel 1^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.bUnderrange" VarB="RTD Inputs Channel 1^Status^Underrange" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^Term 40 (EK1100)^EL3202-0010_M3K4US1_M3K4US2">
 				<Link VarA="PlcTask Inputs^GVL_M3K4_RTD.nM3K4US_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_M3K4_RTD.nM3K4US_RTD_2" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.bError" VarB="RTD Inputs Channel 2^Status^Error" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.bOverrange" VarB="RTD Inputs Channel 2^Status^Overrange" AutoLink="true" Size="1"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.bUnderrange" VarB="RTD Inputs Channel 2^Status^Underrange" AutoLink="true" Size="1"/>
 				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^Term 40 (EK1100)^EL3202-0010_M3K4US3_M3K4DS1">

--- a/lcls-plc-tmo-optics/_Config/PLC/tmo_optics.xti
+++ b/lcls-plc-tmo-optics/_Config/PLC/tmo_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{7FA5AD82-8B94-448C-8921-86A608467E2A}" Name="tmo_optics" PrjFilePath="..\..\tmo_optics\tmo_optics.plcproj" TmcFilePath="..\..\tmo_optics\tmo_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_optics\tmo_optics.tmc" TmcHash="{B751D60F-6A36-0A2F-8955-4284BCC779DF}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_optics\tmo_optics.tmc" TmcHash="{98D8E40B-E062-6F2F-8E5B-11A930123EFC}">
 			<Name>tmo_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -1371,7 +1371,7 @@ External Setpoint Generation:
 			<Vars VarGrpType="1" ContextId="2" AreaNo="32">
 				<Name>PlcTask Inputs</Name>
 				<Var>
-					<Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
+					<Name>lcls_twincat_optics_nrw.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
 					<Comment><![CDATA[Raw encoder count]]></Comment>
 					<Type>LINT</Type>
 				</Var>
@@ -2559,11 +2559,6 @@ External Setpoint Generation:
 					<Type>INT</Type>
 				</Var>
 				<Var>
-					<Name>GVL_M1K4.M1K4_Pitch.diEncCnt</Name>
-					<Comment><![CDATA[Raw encoder count]]></Comment>
-					<Type>LINT</Type>
-				</Var>
-				<Var>
 					<Name>GVL_M2K4_RTD.nM2K4US_RTD_3</Name>
 					<Type>INT</Type>
 				</Var>
@@ -2571,6 +2566,11 @@ External Setpoint Generation:
 					<Name>GVL_M2K4_RTD.nM2K4DS_RTD_1</Name>
 					<Comment><![CDATA[ M2K4 DS RTDs]]></Comment>
 					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>GVL_M1K4.M1K4_Pitch.diEncCnt</Name>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
+					<Type>LINT</Type>
 				</Var>
 				<Var>
 					<Name>GVL_M2K4_RTD.nM2K4DS_RTD_2</Name>
@@ -2701,6 +2701,198 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>GVL_M5K4_RTD.nM5K4_Chin_Tail_RTD.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingLTemp.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingLTemp.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingLTemp.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingLTemp.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingRTemp.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingRTemp.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingRTemp.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingRTemp.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingLTemp.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingLTemp.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingLTemp.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingLTemp.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingRTemp.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingRTemp.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingRTemp.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingRTemp.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.iRaw</Name>
+					<Type>INT</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.bError</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.bUnderrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.bOverrange</Name>
+					<Type>BOOL</Type>
+				</Var>
+				<Var>
+					<Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.iRaw</Name>
 					<Type>INT</Type>
 				</Var>
 			</Vars>
@@ -3302,10 +3494,14 @@ External Setpoint Generation:
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^Term 40 (EK1100)^EL3202-0010_M2K4DS2_M2K4DS3">
 				<Link VarA="PlcTask Inputs^GVL_M2K4_RTD.nM2K4DS_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_M2K4_RTD.nM2K4DS_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^Term 40 (EK1100)^EL3202-0010_M2K4US1_M2K4US2">
 				<Link VarA="PlcTask Inputs^GVL_M2K4_RTD.nM2K4US_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_M2K4_RTD.nM2K4US_RTD_2" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^Term 40 (EK1100)^EL3202-0010_M2K4US3_M2K4DS1">
 				<Link VarA="PlcTask Inputs^GVL_M2K4_RTD.nM2K4DS_RTD_1" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
@@ -3314,10 +3510,14 @@ External Setpoint Generation:
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^Term 40 (EK1100)^EL3202-0010_M3K4DS2_M3K4DS3">
 				<Link VarA="PlcTask Inputs^GVL_M3K4_RTD.nM3K4DS_RTD_2" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_M3K4_RTD.nM3K4DS_RTD_3" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.iRaw" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^Term 40 (EK1100)^EL3202-0010_M3K4US1_M3K4US2">
 				<Link VarA="PlcTask Inputs^GVL_M3K4_RTD.nM3K4US_RTD_1" VarB="RTD Inputs Channel 1^Value" AutoLink="true"/>
 				<Link VarA="PlcTask Inputs^GVL_M3K4_RTD.nM3K4US_RTD_2" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
+				<Link VarA="PlcTask Inputs^P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.iRaw" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TIID^Device 1 (EtherCAT)^Term 1 (EK1200)^Term 5 (EK1122)^Term 40 (EK1100)^EL3202-0010_M3K4US3_M3K4DS1">
 				<Link VarA="PlcTask Inputs^GVL_M3K4_RTD.nM3K4DS_RTD_1" VarB="RTD Inputs Channel 2^Value" AutoLink="true"/>

--- a/lcls-plc-tmo-optics/tmo_optics/POUs/MAIN.TcPOU
+++ b/lcls-plc-tmo-optics/tmo_optics/POUs/MAIN.TcPOU
@@ -580,7 +580,7 @@ VAR
             '}
             fM2K4US_RTD_1 : REAL;
             {attribute 'pytmc' := '
-                pv: MR2K4:KBO:RTD:BEND:US:2
+                pv: MR2K4:KBO:RTD:CHIN:L
                 field: ASLO 0.1
                 field: EGU C
                 io: i
@@ -603,7 +603,7 @@ VAR
         '}
         fM2K4DS_RTD_1 : REAL;
         {attribute 'pytmc' := '
-            pv: MR2K4:KBO:RTD:BEND:DS:2
+            pv: MR2K4:KBO:RTD:CHIN:R
             field: ASLO 0.1
             field: EGU C
             io: i
@@ -625,7 +625,7 @@ VAR
         '}
         fM3K4US_RTD_1 : REAL;
         {attribute 'pytmc' := '
-            pv: MR3K4:KBO:RTD:BEND:US:2
+            pv: MR3K4:KBO:RTD:CHIN:L
             field: ASLO 0.1
             field: EGU C
             io: i
@@ -647,7 +647,7 @@ VAR
         '}
         fM3K4DS_RTD_1 : REAL;
         {attribute 'pytmc' := '
-            pv: MR3K4:KBO:RTD:BEND:DS:2
+            pv: MR3K4:KBO:RTD:CHIN:R
             field: ASLO 0.1
             field: EGU C
             io: i

--- a/lcls-plc-tmo-optics/tmo_optics/POUs/P_StripeProtections.TcPOU
+++ b/lcls-plc-tmo-optics/tmo_optics/POUs/P_StripeProtections.TcPOU
@@ -25,9 +25,24 @@ Silicon surface: RBV >= 7776781: 0000_0000_0001_1110 (allow everything below 250
 *)
     // MR2K4 Mirror Chin Guard RTDs
     {attribute 'TcLinkTo' := '.ffUpperCoatingLTemp.iRaw := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Value;
+                              .ffUpperCoatingLTemp.bUnderrange := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Status^Underrange;
+                              .ffUpperCoatingLTemp.bOverrange := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Status^Overrange;
+                              .ffUpperCoatingLTemp.bError := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Status^Error;
+
                               .ffUpperCoatingRTemp.iRaw := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Value;
+                              .ffUpperCoatingRTemp.bUnderrange := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Status^Underrange;
+                              .ffUpperCoatingRTemp.bOverrange := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Status^Overrange;
+                              .ffUpperCoatingRTemp.bError := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Status^Error;
+
                               .ffLowerCoatingLTemp.iRaw := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Value;
+                              .ffLowerCoatingLTemp.bUnderrange := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Status^Underrange;
+                              .ffLowerCoatingLTemp.bOverrange := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Status^Overrange;
+                              .ffLowerCoatingLTemp.bError := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Status^Error;
+
                               .ffLowerCoatingRTemp.iRaw := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Value;
+                              .ffLowerCoatingRTemp.bUnderrange := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Status^Underrange;
+                              .ffLowerCoatingRTemp.bOverrange := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Status^Overrange;
+                              .ffLowerCoatingRTemp.bError := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Status^Error
     '}
     {attribute 'pytmc' := '
         pv: MR2K4:KBO
@@ -47,9 +62,25 @@ Silicon surface: RBV <= 4820000: 0000_0000_0001_1110 (allow everything between 2
 *)
     // MR3K4 Mirror Chin Guard RTDs
     {attribute 'TcLinkTo' := '.ffUpperCoatingLTemp.iRaw := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Value;
+                              .ffUpperCoatingLTemp.bUnderrange := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Status^Underrange;
+                              .ffUpperCoatingLTemp.bOverrange := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Status^Overrange;
+                              .ffUpperCoatingLTemp.bError := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Status^Error;
+
+
                               .ffUpperCoatingRTemp.iRaw := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Value;
+                              .ffUpperCoatingRTemp.bUnderrange := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Status^Underrange;
+                              .ffUpperCoatingRTemp.bOverrange := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Status^Overrange;
+                              .ffUpperCoatingRTemp.bError := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Status^Error;
+
                               .ffLowerCoatingLTemp.iRaw := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Value;
+                              .ffLowerCoatingLTemp.bUnderrange := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Status^Underrange;
+                              .ffLowerCoatingLTemp.bOverrange := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Status^Overrange;
+                              .ffLowerCoatingLTemp.bError := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Status^Error;
+
                               .ffLowerCoatingRTemp.iRaw := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Value;
+                              .ffLowerCoatingRTemp.bUnderrange := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Status^Underrange;
+                              .ffLowerCoatingRTemp.bOverrange := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Status^Overrange;
+                              .ffLowerCoatingRTemp.bError := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Status^Error
     '}
     {attribute 'pytmc' := '
         pv: MR3K4:KBO

--- a/lcls-plc-tmo-optics/tmo_optics/POUs/P_StripeProtections.TcPOU
+++ b/lcls-plc-tmo-optics/tmo_optics/POUs/P_StripeProtections.TcPOU
@@ -23,6 +23,15 @@ B4C coating: RBV <= 6976835: 1111_1111_1111_1000 (allow everything between 350eV
 Transition: 6976835 < RBV < 7776781: 0000_0000_0000_0000
 Silicon surface: RBV >= 7776781: 0000_0000_0001_1110 (allow everything below 250eV and 450eV)
 *)
+    // MR2K4 Mirror Chin Guard RTDs
+    {attribute 'TcLinkTo' := '.ffUpperCoatingLTemp.iRaw := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Value;
+                              .ffUpperCoatingRTemp.iRaw := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Value;
+                              .ffLowerCoatingLTemp.iRaw := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Value;
+                              .ffLowerCoatingRTemp.iRaw := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Value;
+    '}
+    {attribute 'pytmc' := '
+        pv: MR2K4:KBO
+    '}
      fbStripProtMR2K4 : FB_MirrorTwoCoatingProtection := (
         sDevName := 'MR2K4:KBO',
         nUpperCoatingBoundary := 7776781,
@@ -36,6 +45,15 @@ B4C coating: RBV >= 5620000: 1111_1111_1111_1000 (allow everything between 350eV
 Transition: 4820000 < ENC < 5620000: 0000_0000_0000_0000
 Silicon surface: RBV <= 4820000: 0000_0000_0001_1110 (allow everything between 250eV and 450 eV)
 *)
+    // MR3K4 Mirror Chin Guard RTDs
+    {attribute 'TcLinkTo' := '.ffUpperCoatingLTemp.iRaw := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Value;
+                              .ffUpperCoatingRTemp.iRaw := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Value;
+                              .ffLowerCoatingLTemp.iRaw := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Value;
+                              .ffLowerCoatingRTemp.iRaw := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Value;
+    '}
+    {attribute 'pytmc' := '
+        pv: MR3K4:KBO
+    '}
     fbStripProtMR3K4 : FB_MirrorTwoCoatingProtection := (
         sDevName := 'MR3K4:KBO',
         nUpperCoatingBoundary := 5620000,
@@ -57,6 +75,7 @@ fbStripProtMR2K4(FFO:=GVL_PMPS.g_FastFaultOutput2,
                 neVRange:=PMPS_GVL.stCurrentBeamParameters.neVRange,
                 bReadPmpsDb := MOTION_GVL.fbStandardPMPSDB.bReadPmpsDb,
                 bUsePmpsDb := TRUE,
+                bMirrorTempFaults := TRUE,
                 );
 
 fbStripProtMR3K4(FFO:=GVL_PMPS.g_FastFaultOutput2,
@@ -64,6 +83,7 @@ fbStripProtMR3K4(FFO:=GVL_PMPS.g_FastFaultOutput2,
                 neVRange:=PMPS_GVL.stCurrentBeamParameters.neVRange,
                 bReadPmpsDb := MOTION_GVL.fbStandardPMPSDB.bReadPmpsDb,
                 bUsePmpsDb := TRUE,
+                bMirrorTempFaults := TRUE,
                 );]]></ST>
     </Implementation>
   </POU>

--- a/lcls-plc-tmo-optics/tmo_optics/tmo_optics.plcproj
+++ b/lcls-plc-tmo-optics/tmo_optics/tmo_optics.plcproj
@@ -131,9 +131,9 @@
     <Folder Include="POUs" />
   </ItemGroup>
   <ItemGroup>
-    <PlaceholderReference Include="lcls-twincat-optics">
-      <DefaultResolution>lcls-twincat-optics, * (SLAC)</DefaultResolution>
-      <Namespace>lcls_twincat_optics</Namespace>
+    <PlaceholderReference Include="lcls-twincat-optics-nrw">
+      <DefaultResolution>lcls-twincat-optics-nrw, * (SLAC)</DefaultResolution>
+      <Namespace>lcls_twincat_optics_nrw</Namespace>
     </PlaceholderReference>
     <PlaceholderReference Include="lcls2-cc-lib">
       <DefaultResolution>lcls2-cc-lib, * (SLAC)</DefaultResolution>
@@ -181,9 +181,6 @@
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
       <Resolution>lcls-twincat-motion, 4.0.9 (SLAC)</Resolution>
-    </PlaceholderResolution>
-    <PlaceholderResolution Include="lcls-twincat-optics">
-      <Resolution>lcls-twincat-optics, 0.7.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls2-cc-lib">
       <Resolution>lcls2-cc-lib, 2.0.0 (SLAC)</Resolution>

--- a/lcls-plc-tmo-optics/tmo_optics/tmo_optics.plcproj
+++ b/lcls-plc-tmo-optics/tmo_optics/tmo_optics.plcproj
@@ -131,9 +131,9 @@
     <Folder Include="POUs" />
   </ItemGroup>
   <ItemGroup>
-    <PlaceholderReference Include="lcls-twincat-optics-nrw">
-      <DefaultResolution>lcls-twincat-optics-nrw, * (SLAC)</DefaultResolution>
-      <Namespace>lcls_twincat_optics_nrw</Namespace>
+    <PlaceholderReference Include="lcls-twincat-optics">
+      <DefaultResolution>lcls-twincat-optics, * (SLAC)</DefaultResolution>
+      <Namespace>lcls_twincat_optics</Namespace>
     </PlaceholderReference>
     <PlaceholderReference Include="lcls2-cc-lib">
       <DefaultResolution>lcls2-cc-lib, * (SLAC)</DefaultResolution>
@@ -181,6 +181,9 @@
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
       <Resolution>lcls-twincat-motion, 4.0.9 (SLAC)</Resolution>
+    </PlaceholderResolution>
+    <PlaceholderResolution Include="lcls-twincat-optics">
+      <Resolution>lcls-twincat-optics, 0.8.0 (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls2-cc-lib">
       <Resolution>lcls2-cc-lib, 2.0.0 (SLAC)</Resolution>

--- a/lcls-plc-tmo-optics/tmo_optics/tmo_optics.tmc
+++ b/lcls-plc-tmo-optics/tmo_optics/tmo_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{98D8E40B-E062-6F2F-8E5B-11A930123EFC}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{81FA48AF-9C07-B957-924C-934A08B8467F}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -959,7 +959,7 @@
       <BaseType>STRING(255)</BaseType>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Name>
+      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Name>
       <BitSize>384</BitSize>
       <SubItem>
         <Name>tCtrlCycleTime</Name>
@@ -1033,7 +1033,7 @@
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">ST_PiezoAxis</Name>
+      <Name Namespace="lcls_twincat_optics">ST_PiezoAxis</Name>
       <BitSize>2240</BitSize>
       <SubItem>
         <Name>sIdn</Name>
@@ -1162,7 +1162,7 @@
       </SubItem>
       <SubItem>
         <Name>stPIParams</Name>
-        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
+        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
         <BitSize>384</BitSize>
         <BitOffs>1792</BitOffs>
         <Default>
@@ -2743,7 +2743,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialTransaction</Name>
+      <Name Namespace="lcls_twincat_optics">FB_PI_E621_SerialTransaction</Name>
       <BitSize>33248</BitSize>
       <SubItem>
         <Name>i_xExecute</Name>
@@ -3037,7 +3037,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialDriver</Name>
+      <Name Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</Name>
       <BitSize>109632</BitSize>
       <SubItem>
         <Name>i_xExecute</Name>
@@ -3140,7 +3140,7 @@
       </SubItem>
       <SubItem>
         <Name>iq_stPiezoAxis</Name>
-        <Type Namespace="lcls_twincat_optics_nrw" ReferenceTo="true">ST_PiezoAxis</Type>
+        <Type Namespace="lcls_twincat_optics" ReferenceTo="true">ST_PiezoAxis</Type>
         <BitSize>32</BitSize>
         <BitOffs>66976</BitOffs>
         <Properties>
@@ -3200,7 +3200,7 @@
       </SubItem>
       <SubItem>
         <Name>fbPITransaction</Name>
-        <Type Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialTransaction</Type>
+        <Type Namespace="lcls_twincat_optics">FB_PI_E621_SerialTransaction</Type>
         <BitSize>33248</BitSize>
         <BitOffs>67872</BitOffs>
       </SubItem>
@@ -3245,11 +3245,11 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</Name>
+      <Name Namespace="lcls_twincat_optics">HOMS_PitchMechanism</Name>
       <BitSize>2496</BitSize>
       <SubItem>
         <Name>Piezo</Name>
-        <Type Namespace="lcls_twincat_optics_nrw">ST_PiezoAxis</Type>
+        <Type Namespace="lcls_twincat_optics">ST_PiezoAxis</Type>
         <Comment>Piezo</Comment>
         <BitSize>2240</BitSize>
         <BitOffs>0</BitOffs>
@@ -45868,1899 +45868,6 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_EL5042_Status</Name>
-      <BitSize>0</BitSize>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Name>
-      <Comment> Renishaw BiSS-C absolute encoder used with an EL5042</Comment>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>Count</Name>
-        <Type>ULINT</Type>
-        <Comment> Connect to encoder "Position" input</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>0</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Status</Name>
-        <Type Namespace="lcls_twincat_motion">ST_EL5042_Status</Type>
-        <Comment> Status struct placeholder</Comment>
-        <BitSize>0</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>Ref</Name>
-        <Type>ULINT</Type>
-        <Comment> Encoder zero position (useful for aligned position with gantries)</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_GantryDiffVirtualLimitSwitch</Name>
-      <BitSize>512</BitSize>
-      <SubItem>
-        <Name>PEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <Comment> Primary axis encoder (usually the upstream one)</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>SEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <Comment> Secondary axis encoder (couples to the primary)</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>GantDiffTol</Name>
-        <Type>LINT</Type>
-        <Comment> Gantry differenace tolerance in encoder counts</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>PLimFwd</Name>
-        <Type>BOOL</Type>
-        <Comment> Primary axis forward direction enable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>PLimBwd</Name>
-        <Type>BOOL</Type>
-        <Comment> Primary axis reverse direction enable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>392</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>SLimFwd</Name>
-        <Type>BOOL</Type>
-        <Comment> Secondary axis forward direction enable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>400</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>SLimBwd</Name>
-        <Type>BOOL</Type>
-        <Comment> Secondary axis reverse direction enable</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>408</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>GantryDiff</Name>
-        <Type>LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">_E_TcNC_SlaveTypes</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_LINEAR</Text>
-        <Enum>1</Enum>
-        <Comment> Lineare Kopplung (Geradengleichung) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_FLYINGSAW_ONVELOCITY</Text>
-        <Enum>2</Enum>
-        <Comment> diagonal synchron. Aufkoppeln schnellstens auf Geschwindigkeit </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_FLYINGSAW_ONPOSITION</Text>
-        <Enum>3</Enum>
-        <Comment> diagonal synchron. Aufkoppeln auf Position und Geschwindigkeit </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_FLYINGSAW_QUADRATIC</Text>
-        <Enum>4</Enum>
-        <Comment> diagonal synchron. Aufkoppeln (quadratisches Geschw.-Profil) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_SYNCHRONIZING_ONVELO</Text>
-        <Enum>5</Enum>
-        <Comment> synchron. Aufkoppeln instantan auf Geschwindigkeit </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_SYNCHRONIZING_ONPOS</Text>
-        <Enum>6</Enum>
-        <Comment> synchron. Aufkoppeln auf Positionen und Geschwindigkeit </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_SYNCJERKSETTER_ONVELO</Text>
-        <Enum>7</Enum>
-        <Comment> synchron. Aufkoppeln auf Geschwindigkeit (zeitbasiert mittels Ruck-Steller) </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_TABULAR</Text>
-        <Enum>10</Enum>
-        <Comment> Tabellen-Kopplung ("simple/standard tabular slave") </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_MULTITABULAR</Text>
-        <Enum>11</Enum>
-        <Comment> Tabellen-Kopplung ("multiscalable multi-tabular slave") </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_FLYINGMODULO_LINEAR</Text>
-        <Enum>12</Enum>
-        <Comment> Modulo Kopplung auf Position und/oder Geschwindigkeit mit anschliessender Linear Kopplung ("Schuette") </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_MOTIONFUNCTIONTABULAR</Text>
-        <Enum>13</Enum>
-        <Comment> Tabellen-Kopplung "motion functions" </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_UNIVERSALTABULAR</Text>
-        <Enum>14</Enum>
-        <Comment> Tabellen-Kopplung, universal tabular type substitues TABULAR, MULTITABULAR and MOTIONFUNCTION - 08.07.05 </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_LINEAR_CYCLICCHANGES_RAMP</Text>
-        <Enum>15</Enum>
-        <Comment> Lineare Kopplung (Geradengleichung) mit zyklischer Koppelfaktoraenderung </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_BILINEAR</Text>
-        <Enum>16</Enum>
-        <Comment> 27.04.01: Zweifach Lineare Kopplung (Geradengleichung)</Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_LINEAR_MULTIMASTER</Text>
-        <Enum>17</Enum>
-        <Comment> 29.05.08: Lineare Multi-Master-Kopplung ('MC_GearInMultiMaster') </Comment>
-      </EnumInfo>
-      <EnumInfo>
-        <Text>TCNC_SLAVETYPE_CONST_SURFACEVELO_RAMP</Text>
-        <Enum>18</Enum>
-        <Comment> Verrechnete Winkelgeschwindigkeit fuer konstante Oberflaechengeschwindig. in Abhaengigkeit vom Radiusistwert des Enc.2 </Comment>
-      </EnumInfo>
-      <Properties>
-        <Property>
-          <Name>conditionalshow</Name>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">ST_GearInOptions</Name>
-      <BitSize>16</BitSize>
-      <SubItem>
-        <Name>SlaveType</Name>
-        <Type Namespace="Tc2_MC2">_E_TcNC_SlaveTypes</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="Tc2_MC2">MC_GearIn</Name>
-      <BitSize>6656</BitSize>
-      <SubItem>
-        <Name>Master</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Slave</Name>
-        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
-        <Comment>Reference to an axis</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Execute</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>RatioNumerator</Name>
-        <Type>LREAL</Type>
-        <Comment> changed from INT (PLCopen) to LREAL </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>RatioDenominator</Name>
-        <Type>UINT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>192</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Acceleration</Name>
-        <Type>LREAL</Type>
-        <Comment>	MasterValueSource :	MC_SOURCE; 
- not available </Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Deceleration</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Jerk</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>BufferMode</Name>
-        <Type Namespace="Tc2_MC2">MC_BufferMode</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Options</Name>
-        <Type Namespace="Tc2_MC2">ST_GearInOptions</Type>
-        <Comment> optional parameters </Comment>
-        <BitSize>16</BitSize>
-        <BitOffs>464</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>InGear</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>480</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Busy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>488</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Active</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>496</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>CommandAborted</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>504</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Error</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ErrorID</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>544</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>displaymode</Name>
-            <Value>hex</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>LastExecutionResult</Name>
-        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ADSbusy</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>672</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>iState</Name>
-        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>688</BitOffs>
-        <Default>
-          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbAdsWrite</Name>
-        <Type Namespace="Tc2_System">ADSWRITE</Type>
-        <BitSize>1216</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sCouple</Name>
-        <Type Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Type>
-        <BitSize>384</BitSize>
-        <BitOffs>1920</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbOptGearInDyn</Name>
-        <Type Namespace="Tc2_MC2">MC_GearInDyn</Type>
-        <BitSize>4032</BitSize>
-        <BitOffs>2304</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbOnTrigger</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>6336</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>TimerStateFeedback</Name>
-        <Type Namespace="Tc2_Standard">TON</Type>
-        <BitSize>224</BitSize>
-        <BitOffs>6400</BitOffs>
-        <Properties>
-          <Property>
-            <Name>conditionalshow</Name>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Action>
-        <Name>ActGearInDyn</Name>
-      </Action>
-      <Action>
-        <Name>WriteGearRatio</Name>
-      </Action>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Name>
-      <BitSize>9472</BitSize>
-      <SubItem>
-        <Name>nGantryTol</Name>
-        <Type>LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupled</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Master</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>MasterEnc</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_RenishawAbsEnc</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>Slave</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>SlaveEnc</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_RenishawAbsEnc</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCouple</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecouple</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>gantry_diff_limit</Name>
-        <Type Namespace="lcls_twincat_motion">FB_GantryDiffVirtualLimitSwitch</Type>
-        <BitSize>512</BitSize>
-        <BitOffs>384</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>couple</Name>
-        <Type Namespace="Tc2_MC2">MC_GearIn</Type>
-        <BitSize>6656</BitSize>
-        <BitOffs>896</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>decouple</Name>
-        <Type Namespace="Tc2_MC2">MC_GearOut</Type>
-        <BitSize>1792</BitSize>
-        <BitOffs>7552</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bInitComplete</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>9344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbSetEnables</Name>
-        <Type Namespace="lcls_twincat_motion">FB_SetEnables</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>9376</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_RunHOMS</Name>
-      <BitSize>20416</BitSize>
-      <SubItem>
-        <Name>nYupEncRef</Name>
-        <Type>ULINT</Type>
-        <Comment> Encoder Reference Values</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nYdwnEncRef</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nXupEncRef</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nXdwnEncRef</Name>
-        <Type>ULINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nGantryTolY</Name>
-        <Type>LINT</Type>
-        <Comment> Encoder counts = nm</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Default>
-          <Value>50000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nGantryTolX</Name>
-        <Type>LINT</Type>
-        <Comment> Encoder counts = nm</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Default>
-          <Value>50000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupledY</Name>
-        <Type>BOOL</Type>
-        <Comment> Gantry coupling status</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupledX</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>456</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGantryY</Name>
-        <Type>LINT</Type>
-        <Comment> Current gantry difference</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>512</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGantryX</Name>
-        <Type>LINT</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>576</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYup</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <Comment> Motor Structs</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>640</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYdwn</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>672</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stXup</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>704</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stXdwn</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>736</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stPitch</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>768</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCoupleY</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <Comment> Manual coupling Gantried Axes</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>800</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCoupleX</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>832</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecoupleY</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>864</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecoupleX</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSTOEnable1</Name>
-        <Type>BOOL</Type>
-        <Comment> STO Button</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>928</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSTOEnable2</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>936</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYupEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <Comment> Encoders</Comment>
-        <BitSize>128</BitSize>
-        <BitOffs>960</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stYdwnEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1088</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stXupEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1216</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stXdwnEnc</Name>
-        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-        <BitSize>128</BitSize>
-        <BitOffs>1344</BitOffs>
-        <Properties>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fbAutoCoupleY</Name>
-        <Type Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Type>
-        <Comment> Autocoupling Gantried Axes</Comment>
-        <BitSize>9472</BitSize>
-        <BitOffs>1472</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbAutoCoupleX</Name>
-        <Type Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Type>
-        <BitSize>9472</BitSize>
-        <BitOffs>10944</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">DUT_HOMS</Name>
-      <BitSize>20672</BitSize>
-      <SubItem>
-        <Name>fbRunHOMS</Name>
-        <Type Namespace="lcls_twincat_optics_nrw">FB_RunHOMS</Type>
-        <Comment> System initializiation</Comment>
-        <BitSize>20416</BitSize>
-        <BitOffs>0</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCoupleY</Name>
-        <Type>BOOL</Type>
-        <Comment> Couple/Decouple motors</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>20416</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: COUPLE_Y
-        io: o
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecoupleY</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>20424</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DECOUPLE_Y
-        io: o
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteCoupleX</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>20432</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: COUPLE_X
-        io: o
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDecoupleX</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>20440</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: DECOUPLE_X
-        io: o
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupledY</Name>
-        <Type>BOOL</Type>
-        <Comment> Coupling status</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>20448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ALREADY_COUPLED_Y
-        io: i
-        field: ZSV MAJOR
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bGantryAlreadyCoupledX</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>20456</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ALREADY_COUPLED_X
-        io: i
-        field: ZSV MAJOR
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGantryY</Name>
-        <Type>LINT</Type>
-        <Comment> encoder counts = nm</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>20480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nCurrGantryX</Name>
-        <Type>LINT</Type>
-        <Comment> encoder counts = nm</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>20544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fCurrGantryY_um</Name>
-        <Type>REAL</Type>
-        <Comment> Y Gantry difference in um</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>20608</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: GANTRY_Y
-        field: EGU um
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fCurrGantryX_um</Name>
-        <Type>REAL</Type>
-        <Comment> X Gantry difference in um</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>20640</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: GANTRY_X
-        field: EGU um
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_DataBuffer</Name>
-      <BitSize>288</BitSize>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> Whether or not to accumulate on this cycle</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pInputAdr</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Address of the value to accumulate</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iInputSize</Name>
-        <Type>UDINT</Type>
-        <Comment> Size of the accumulated value</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iElemCount</Name>
-        <Type>UDINT</Type>
-        <Comment> Number of values in the output array</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pPartialAdr</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Address of the rolling buffer to be filled every cycle</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>pOutputAdr</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
-        <Comment> Address of the output buffer to be filled when the rolling buffer is full</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bNewArray</Name>
-        <Type>BOOL</Type>
-        <Comment> Set to TRUE on the cycle that we copy the output array</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>224</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>iArrayIndex</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>256</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_LREALBuffer</Name>
-      <BitSize>128512</BitSize>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we'll accumulate a value on this cycle.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fInput</Name>
-        <Type>LREAL</Type>
-        <Comment> The value to accumulate.</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>arrOutput</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>1000</Elements>
-        </ArrayInfo>
-        <BitSize>64000</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bNewArray</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>64128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>arrPartial</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>1000</Elements>
-        </ArrayInfo>
-        <BitSize>64000</BitSize>
-        <BitOffs>64192</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbDataBuffer</Name>
-        <Type Namespace="LCLS_General">FB_DataBuffer</Type>
-        <BitSize>288</BitSize>
-        <BitOffs>128192</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="LCLS_General">FB_BasicStats</Name>
-      <BitSize>896</BitSize>
-      <SubItem>
-        <Name>aSignal</Name>
-        <Type PointerTo="1">LREAL</Type>
-        <Comment> Input array of floats</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:DATA
-        io: i
-    </Value>
-          </Property>
-          <Property>
-            <Name>variable_length_array</Name>
-          </Property>
-          <Property>
-            <Name>Dimensions</Name>
-            <Value>1</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAlwaysCalc</Name>
-        <Type>BOOL</Type>
-        <Comment> If TRUE, we will update the results every cycle</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATS:ALWAYS_CALC</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bExecute</Name>
-        <Type>BOOL</Type>
-        <Comment> On rising edge, do one calculation</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>72</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATS:EXECUTE</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReset</Name>
-        <Type>BOOL</Type>
-        <Comment> If set to TRUE, reset outputs</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>80</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>pv: STATS:RESET</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nElems</Name>
-        <Type>UDINT</Type>
-        <Comment> If nonzero, we will only pay attention to the first nElems items in aSignal</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:NELM
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fMean</Name>
-        <Type>LREAL</Type>
-        <Comment> Average of all values in the array</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:MEAN
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fStDev</Name>
-        <Type>LREAL</Type>
-        <Comment> Standard deviation of all values in the array</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:STDEV
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fMax</Name>
-        <Type>LREAL</Type>
-        <Comment> Largest value in the array</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:MAX
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fMin</Name>
-        <Type>LREAL</Type>
-        <Comment> Smallest value in the array</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:MIN
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fRange</Name>
-        <Type>LREAL</Type>
-        <Comment> Largest array element subtracted by the smallest</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:RANGE
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bValid</Name>
-        <Type>BOOL</Type>
-        <Comment> True if the other outputs are valid</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>448</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STATS:VALID
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>rTrig</Name>
-        <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>480</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nElemsSeen</Name>
-        <Type>UDINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>576</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fSum</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>640</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fVarianceSum</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>704</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fVarianceMean</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>768</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</Name>
-      <BitSize>386880</BitSize>
-      <SubItem>
-        <Name>fMaxRMSError</Name>
-        <Type>LREAL</Type>
-        <Comment> RMS Error</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>64</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fMinRMSError</Name>
-        <Type>LREAL</Type>
-        <Comment> start at something huge, FB will update with any smaller measured value</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>128</BitOffs>
-        <Default>
-          <Value>1000</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Output</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>192</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fEncScalingNum</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>256</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fEncScalingDenom</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>320</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fEncOffset</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>384</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fEncScale</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>448</BitOffs>
-        <Default>
-          <Value>1</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fbDataEncPos</Name>
-        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
-        <Comment> ActPos Data Acquisition FB</Comment>
-        <BitSize>128512</BitSize>
-        <BitOffs>512</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbDataSetPos</Name>
-        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
-        <Comment> SetPos Data Acquisition FB</Comment>
-        <BitSize>128512</BitSize>
-        <BitOffs>129024</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bExecuteDataStorage</Name>
-        <Type>BOOL</Type>
-        <Comment> Take data of both ActPos and SetPos</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>257536</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bNewEncArray</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>257544</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbStats</Name>
-        <Type Namespace="LCLS_General">FB_BasicStats</Type>
-        <Comment> Calculate mean/standard deviation of ActPos</Comment>
-        <BitSize>896</BitSize>
-        <BitOffs>257600</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fEncMean</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>258496</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: MEAN
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fEncStDev</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>258560</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: STDEV
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>fCurrRMSError</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>258624</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: RMS
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nIndex</Name>
-        <Type>DINT</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>258688</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fSum</Name>
-        <Type>LREAL</Type>
-        <Comment> Just for calculating rms</Comment>
-        <BitSize>64</BitSize>
-        <BitOffs>258752</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>fDiff</Name>
-        <Type>LREAL</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>258816</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>aEncActPos</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>1000</Elements>
-        </ArrayInfo>
-        <BitSize>64000</BitSize>
-        <BitOffs>258880</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: ACTPOSARRAY
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>aEncSetPos</Name>
-        <Type>LREAL</Type>
-        <ArrayInfo>
-          <LBound>1</LBound>
-          <Elements>1000</Elements>
-        </ArrayInfo>
-        <BitSize>64000</BitSize>
-        <BitOffs>322880</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: SETPOSARRAY
-        io: i
-    </Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_Bender</Name>
-      <BitSize>128</BitSize>
-      <SubItem>
-        <Name>stBender</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSTOEnable1</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bSTOEnable2</Name>
-        <Type ReferenceTo="true">BOOL</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>96</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
       <Name Namespace="Tc2_MC2">E_ReadMode</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
@@ -60008,6 +58115,1207 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_EL5042_Status</Name>
+      <BitSize>0</BitSize>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Name>
+      <Comment> Renishaw BiSS-C absolute encoder used with an EL5042</Comment>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>Count</Name>
+        <Type>ULINT</Type>
+        <Comment> Connect to encoder "Position" input</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>0</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Status</Name>
+        <Type Namespace="lcls_twincat_motion">ST_EL5042_Status</Type>
+        <Comment> Status struct placeholder</Comment>
+        <BitSize>0</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Ref</Name>
+        <Type>ULINT</Type>
+        <Comment> Encoder zero position (useful for aligned position with gantries)</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_GantryDiffVirtualLimitSwitch</Name>
+      <BitSize>512</BitSize>
+      <SubItem>
+        <Name>PEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <Comment> Primary axis encoder (usually the upstream one)</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <Comment> Secondary axis encoder (couples to the primary)</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>GantDiffTol</Name>
+        <Type>LINT</Type>
+        <Comment> Gantry differenace tolerance in encoder counts</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PLimFwd</Name>
+        <Type>BOOL</Type>
+        <Comment> Primary axis forward direction enable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>PLimBwd</Name>
+        <Type>BOOL</Type>
+        <Comment> Primary axis reverse direction enable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>392</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SLimFwd</Name>
+        <Type>BOOL</Type>
+        <Comment> Secondary axis forward direction enable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SLimBwd</Name>
+        <Type>BOOL</Type>
+        <Comment> Secondary axis reverse direction enable</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>408</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>GantryDiff</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">_E_TcNC_SlaveTypes</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_LINEAR</Text>
+        <Enum>1</Enum>
+        <Comment> Lineare Kopplung (Geradengleichung) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_FLYINGSAW_ONVELOCITY</Text>
+        <Enum>2</Enum>
+        <Comment> diagonal synchron. Aufkoppeln schnellstens auf Geschwindigkeit </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_FLYINGSAW_ONPOSITION</Text>
+        <Enum>3</Enum>
+        <Comment> diagonal synchron. Aufkoppeln auf Position und Geschwindigkeit </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_FLYINGSAW_QUADRATIC</Text>
+        <Enum>4</Enum>
+        <Comment> diagonal synchron. Aufkoppeln (quadratisches Geschw.-Profil) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_SYNCHRONIZING_ONVELO</Text>
+        <Enum>5</Enum>
+        <Comment> synchron. Aufkoppeln instantan auf Geschwindigkeit </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_SYNCHRONIZING_ONPOS</Text>
+        <Enum>6</Enum>
+        <Comment> synchron. Aufkoppeln auf Positionen und Geschwindigkeit </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_SYNCJERKSETTER_ONVELO</Text>
+        <Enum>7</Enum>
+        <Comment> synchron. Aufkoppeln auf Geschwindigkeit (zeitbasiert mittels Ruck-Steller) </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_TABULAR</Text>
+        <Enum>10</Enum>
+        <Comment> Tabellen-Kopplung ("simple/standard tabular slave") </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_MULTITABULAR</Text>
+        <Enum>11</Enum>
+        <Comment> Tabellen-Kopplung ("multiscalable multi-tabular slave") </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_FLYINGMODULO_LINEAR</Text>
+        <Enum>12</Enum>
+        <Comment> Modulo Kopplung auf Position und/oder Geschwindigkeit mit anschliessender Linear Kopplung ("Schuette") </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_MOTIONFUNCTIONTABULAR</Text>
+        <Enum>13</Enum>
+        <Comment> Tabellen-Kopplung "motion functions" </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_UNIVERSALTABULAR</Text>
+        <Enum>14</Enum>
+        <Comment> Tabellen-Kopplung, universal tabular type substitues TABULAR, MULTITABULAR and MOTIONFUNCTION - 08.07.05 </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_LINEAR_CYCLICCHANGES_RAMP</Text>
+        <Enum>15</Enum>
+        <Comment> Lineare Kopplung (Geradengleichung) mit zyklischer Koppelfaktoraenderung </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_BILINEAR</Text>
+        <Enum>16</Enum>
+        <Comment> 27.04.01: Zweifach Lineare Kopplung (Geradengleichung)</Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_LINEAR_MULTIMASTER</Text>
+        <Enum>17</Enum>
+        <Comment> 29.05.08: Lineare Multi-Master-Kopplung ('MC_GearInMultiMaster') </Comment>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>TCNC_SLAVETYPE_CONST_SURFACEVELO_RAMP</Text>
+        <Enum>18</Enum>
+        <Comment> Verrechnete Winkelgeschwindigkeit fuer konstante Oberflaechengeschwindig. in Abhaengigkeit vom Radiusistwert des Enc.2 </Comment>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">ST_GearInOptions</Name>
+      <BitSize>16</BitSize>
+      <SubItem>
+        <Name>SlaveType</Name>
+        <Type Namespace="Tc2_MC2">_E_TcNC_SlaveTypes</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="Tc2_MC2">MC_GearIn</Name>
+      <BitSize>6656</BitSize>
+      <SubItem>
+        <Name>Master</Name>
+        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Slave</Name>
+        <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
+        <Comment>Reference to an axis</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Execute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>RatioNumerator</Name>
+        <Type>LREAL</Type>
+        <Comment> changed from INT (PLCopen) to LREAL </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>RatioDenominator</Name>
+        <Type>UINT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Acceleration</Name>
+        <Type>LREAL</Type>
+        <Comment>	MasterValueSource :	MC_SOURCE; 
+ not available </Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Deceleration</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Jerk</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>BufferMode</Name>
+        <Type Namespace="Tc2_MC2">MC_BufferMode</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Options</Name>
+        <Type Namespace="Tc2_MC2">ST_GearInOptions</Type>
+        <Comment> optional parameters </Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>464</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>InGear</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>480</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Busy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>488</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Active</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>496</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>CommandAborted</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>504</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Error</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ErrorID</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>544</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>displaymode</Name>
+            <Value>hex</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>LastExecutionResult</Name>
+        <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
+        <BitSize>96</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ADSbusy</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>672</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>iState</Name>
+        <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>688</BitOffs>
+        <Default>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbAdsWrite</Name>
+        <Type Namespace="Tc2_System">ADSWRITE</Type>
+        <BitSize>1216</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sCouple</Name>
+        <Type Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Type>
+        <BitSize>384</BitSize>
+        <BitOffs>1920</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbOptGearInDyn</Name>
+        <Type Namespace="Tc2_MC2">MC_GearInDyn</Type>
+        <BitSize>4032</BitSize>
+        <BitOffs>2304</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbOnTrigger</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>6336</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>TimerStateFeedback</Name>
+        <Type Namespace="Tc2_Standard">TON</Type>
+        <BitSize>224</BitSize>
+        <BitOffs>6400</BitOffs>
+        <Properties>
+          <Property>
+            <Name>conditionalshow</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Action>
+        <Name>ActGearInDyn</Name>
+      </Action>
+      <Action>
+        <Name>WriteGearRatio</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Name>
+      <BitSize>9472</BitSize>
+      <SubItem>
+        <Name>nGantryTol</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupled</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Master</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>MasterEnc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_RenishawAbsEnc</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>Slave</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>SlaveEnc</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_RenishawAbsEnc</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCouple</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>288</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecouple</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>gantry_diff_limit</Name>
+        <Type Namespace="lcls_twincat_motion">FB_GantryDiffVirtualLimitSwitch</Type>
+        <BitSize>512</BitSize>
+        <BitOffs>384</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>couple</Name>
+        <Type Namespace="Tc2_MC2">MC_GearIn</Type>
+        <BitSize>6656</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>decouple</Name>
+        <Type Namespace="Tc2_MC2">MC_GearOut</Type>
+        <BitSize>1792</BitSize>
+        <BitOffs>7552</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bInitComplete</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>9344</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbSetEnables</Name>
+        <Type Namespace="lcls_twincat_motion">FB_SetEnables</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>9376</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_RunHOMS</Name>
+      <BitSize>20416</BitSize>
+      <SubItem>
+        <Name>nYupEncRef</Name>
+        <Type>ULINT</Type>
+        <Comment> Encoder Reference Values</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nYdwnEncRef</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nXupEncRef</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nXdwnEncRef</Name>
+        <Type>ULINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGantryTolY</Name>
+        <Type>LINT</Type>
+        <Comment> Encoder counts = nm</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>50000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nGantryTolX</Name>
+        <Type>LINT</Type>
+        <Comment> Encoder counts = nm</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <Value>50000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupledY</Name>
+        <Type>BOOL</Type>
+        <Comment> Gantry coupling status</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupledX</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGantryY</Name>
+        <Type>LINT</Type>
+        <Comment> Current gantry difference</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>512</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGantryX</Name>
+        <Type>LINT</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>576</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stYup</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <Comment> Motor Structs</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stYdwn</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>672</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stXup</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>704</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stXdwn</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>736</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stPitch</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCoupleY</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <Comment> Manual coupling Gantried Axes</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>800</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCoupleX</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>832</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecoupleY</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>864</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecoupleX</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>896</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSTOEnable1</Name>
+        <Type>BOOL</Type>
+        <Comment> STO Button</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>928</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSTOEnable2</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>936</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stYupEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <Comment> Encoders</Comment>
+        <BitSize>128</BitSize>
+        <BitOffs>960</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stYdwnEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stXupEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1216</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stXdwnEnc</Name>
+        <Type Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+        <BitSize>128</BitSize>
+        <BitOffs>1344</BitOffs>
+        <Properties>
+          <Property>
+            <Name>TcAddressType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fbAutoCoupleY</Name>
+        <Type Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Type>
+        <Comment> Autocoupling Gantried Axes</Comment>
+        <BitSize>9472</BitSize>
+        <BitOffs>1472</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbAutoCoupleX</Name>
+        <Type Namespace="lcls_twincat_motion">FB_GantryAutoCoupling</Type>
+        <BitSize>9472</BitSize>
+        <BitOffs>10944</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">DUT_HOMS</Name>
+      <BitSize>20672</BitSize>
+      <SubItem>
+        <Name>fbRunHOMS</Name>
+        <Type Namespace="lcls_twincat_optics">FB_RunHOMS</Type>
+        <Comment> System initializiation</Comment>
+        <BitSize>20416</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCoupleY</Name>
+        <Type>BOOL</Type>
+        <Comment> Couple/Decouple motors</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>20416</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: COUPLE_Y
+        io: o
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecoupleY</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>20424</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DECOUPLE_Y
+        io: o
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteCoupleX</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>20432</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: COUPLE_X
+        io: o
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDecoupleX</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>20440</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: DECOUPLE_X
+        io: o
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupledY</Name>
+        <Type>BOOL</Type>
+        <Comment> Coupling status</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>20448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ALREADY_COUPLED_Y
+        io: i
+        field: ZSV MAJOR
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bGantryAlreadyCoupledX</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>20456</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ALREADY_COUPLED_X
+        io: i
+        field: ZSV MAJOR
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGantryY</Name>
+        <Type>LINT</Type>
+        <Comment> encoder counts = nm</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>20480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nCurrGantryX</Name>
+        <Type>LINT</Type>
+        <Comment> encoder counts = nm</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>20544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fCurrGantryY_um</Name>
+        <Type>REAL</Type>
+        <Comment> Y Gantry difference in um</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>20608</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: GANTRY_Y
+        field: EGU um
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fCurrGantryX_um</Name>
+        <Type>REAL</Type>
+        <Comment> X Gantry difference in um</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>20640</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: GANTRY_X
+        field: EGU um
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_Bender</Name>
+      <BitSize>128</BitSize>
+      <SubItem>
+        <Name>stBender</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSTOEnable1</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bSTOEnable2</Name>
+        <Type ReferenceTo="true">BOOL</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="LCLS_General">FB_AnalogInput</Name>
       <BitSize>320</BitSize>
       <SubItem>
@@ -60093,7 +59401,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</Name>
+      <Name Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</Name>
       <BitSize>832</BitSize>
       <SubItem>
         <Name>fFlow_1_val</Name>
@@ -60166,9 +59474,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_2f1p</Name>
+      <Name Namespace="lcls_twincat_optics">FB_Axilon_Cooling_2f1p</Name>
       <BitSize>1216</BitSize>
-      <ExtendsType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</ExtendsType>
+      <ExtendsType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</ExtendsType>
       <SubItem>
         <Name>fFlow_2_val</Name>
         <Type>LREAL</Type>
@@ -73972,6 +73280,719 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
+      <Name Namespace="LCLS_General">FB_DataBuffer</Name>
+      <BitSize>288</BitSize>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> Whether or not to accumulate on this cycle</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pInputAdr</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Address of the value to accumulate</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iInputSize</Name>
+        <Type>UDINT</Type>
+        <Comment> Size of the accumulated value</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iElemCount</Name>
+        <Type>UDINT</Type>
+        <Comment> Number of values in the output array</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pPartialAdr</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Address of the rolling buffer to be filled every cycle</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>pOutputAdr</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000018}">PVOID</Type>
+        <Comment> Address of the output buffer to be filled when the rolling buffer is full</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bNewArray</Name>
+        <Type>BOOL</Type>
+        <Comment> Set to TRUE on the cycle that we copy the output array</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>224</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>iArrayIndex</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_LREALBuffer</Name>
+      <BitSize>128512</BitSize>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we'll accumulate a value on this cycle.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fInput</Name>
+        <Type>LREAL</Type>
+        <Comment> The value to accumulate.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrOutput</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <BitSize>64000</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bNewArray</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>64128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>arrPartial</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <BitSize>64000</BitSize>
+        <BitOffs>64192</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbDataBuffer</Name>
+        <Type Namespace="LCLS_General">FB_DataBuffer</Type>
+        <BitSize>288</BitSize>
+        <BitOffs>128192</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="LCLS_General">FB_BasicStats</Name>
+      <BitSize>896</BitSize>
+      <SubItem>
+        <Name>aSignal</Name>
+        <Type PointerTo="1">LREAL</Type>
+        <Comment> Input array of floats</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:DATA
+        io: i
+    </Value>
+          </Property>
+          <Property>
+            <Name>variable_length_array</Name>
+          </Property>
+          <Property>
+            <Name>Dimensions</Name>
+            <Value>1</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAlwaysCalc</Name>
+        <Type>BOOL</Type>
+        <Comment> If TRUE, we will update the results every cycle</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATS:ALWAYS_CALC</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <Comment> On rising edge, do one calculation</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>72</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATS:EXECUTE</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReset</Name>
+        <Type>BOOL</Type>
+        <Comment> If set to TRUE, reset outputs</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>80</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>pv: STATS:RESET</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nElems</Name>
+        <Type>UDINT</Type>
+        <Comment> If nonzero, we will only pay attention to the first nElems items in aSignal</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>96</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:NELM
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fMean</Name>
+        <Type>LREAL</Type>
+        <Comment> Average of all values in the array</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:MEAN
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fStDev</Name>
+        <Type>LREAL</Type>
+        <Comment> Standard deviation of all values in the array</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:STDEV
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fMax</Name>
+        <Type>LREAL</Type>
+        <Comment> Largest value in the array</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:MAX
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fMin</Name>
+        <Type>LREAL</Type>
+        <Comment> Smallest value in the array</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:MIN
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fRange</Name>
+        <Type>LREAL</Type>
+        <Comment> Largest array element subtracted by the smallest</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:RANGE
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bValid</Name>
+        <Type>BOOL</Type>
+        <Comment> True if the other outputs are valid</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>448</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STATS:VALID
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>rTrig</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>480</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>nElemsSeen</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>576</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fSum</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>640</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVarianceSum</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>704</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fVarianceMean</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>768</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics">FB_RMSWatch</Name>
+      <BitSize>386880</BitSize>
+      <SubItem>
+        <Name>fMaxRMSError</Name>
+        <Type>LREAL</Type>
+        <Comment> RMS Error</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>64</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fMinRMSError</Name>
+        <Type>LREAL</Type>
+        <Comment> start at something huge, FB will update with any smaller measured value</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>128</BitOffs>
+        <Default>
+          <Value>1000</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>stMotionStage</Name>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>192</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScalingNum</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScalingDenom</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fEncOffset</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fEncScale</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>448</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fbDataEncPos</Name>
+        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
+        <Comment> ActPos Data Acquisition FB</Comment>
+        <BitSize>128512</BitSize>
+        <BitOffs>512</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbDataSetPos</Name>
+        <Type Namespace="LCLS_General">FB_LREALBuffer</Type>
+        <Comment> SetPos Data Acquisition FB</Comment>
+        <BitSize>128512</BitSize>
+        <BitOffs>129024</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bExecuteDataStorage</Name>
+        <Type>BOOL</Type>
+        <Comment> Take data of both ActPos and SetPos</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>257536</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bNewEncArray</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>257544</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbStats</Name>
+        <Type Namespace="LCLS_General">FB_BasicStats</Type>
+        <Comment> Calculate mean/standard deviation of ActPos</Comment>
+        <BitSize>896</BitSize>
+        <BitOffs>257600</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fEncMean</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>258496</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: MEAN
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fEncStDev</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>258560</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: STDEV
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fCurrRMSError</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>258624</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: RMS
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nIndex</Name>
+        <Type>DINT</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>258688</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fSum</Name>
+        <Type>LREAL</Type>
+        <Comment> Just for calculating rms</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>258752</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>fDiff</Name>
+        <Type>LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>258816</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>aEncActPos</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <BitSize>64000</BitSize>
+        <BitOffs>258880</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: ACTPOSARRAY
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>aEncSetPos</Name>
+        <Type>LREAL</Type>
+        <ArrayInfo>
+          <LBound>1</LBound>
+          <Elements>1000</Elements>
+        </ArrayInfo>
+        <BitSize>64000</BitSize>
+        <BitOffs>322880</BitOffs>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: SETPOSARRAY
+        io: i
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name>Implicit_Enum__FB_MirrorTwoCoatingProtection__E_CoatingPos</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <EnumInfo>
+        <Text>Upper</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>Lower</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="PMPS">FB_TempSensor_FFO</Name>
       <BitSize>109056</BitSize>
       <ExtendsType Namespace="LCLS_General">FB_TempSensor</ExtendsType>
@@ -74161,8 +74182,8 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics_nrw">FB_MirrorTwoCoatingProtection</Name>
-      <BitSize>629120</BitSize>
+      <Name Namespace="lcls_twincat_optics">FB_MirrorTwoCoatingProtection</Name>
+      <BitSize>629184</BitSize>
       <SubItem>
         <Name>nCurrentEncoderCount</Name>
         <Type>UDINT</Type>
@@ -74366,10 +74387,22 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Properties>
       </SubItem>
       <SubItem>
+        <Name>E_CoatingPos</Name>
+        <Type>Implicit_Enum__FB_MirrorTwoCoatingProtection__E_CoatingPos</Type>
+        <Comment> Coating Enums for local coding, not a readback.</Comment>
+        <BitSize>16</BitSize>
+        <BitOffs>2304</BitOffs>
+        <Properties>
+          <Property>
+            <Name>implicit_enum_type</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
         <Name>ffUpperCoating</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25088</BitSize>
-        <BitOffs>2304</BitOffs>
+        <BitOffs>2336</BitOffs>
         <Default>
           <SubItem>
             <Name>.i_xAutoReset</Name>
@@ -74389,7 +74422,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>ffLowerCoating</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25088</BitSize>
-        <BitOffs>27392</BitOffs>
+        <BitOffs>27424</BitOffs>
         <Default>
           <SubItem>
             <Name>.i_xAutoReset</Name>
@@ -74409,7 +74442,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>ffBeamParamsNotLoaded</Name>
         <Type Namespace="PMPS">FB_FastFault</Type>
         <BitSize>25088</BitSize>
-        <BitOffs>52480</BitOffs>
+        <BitOffs>52512</BitOffs>
         <Default>
           <SubItem>
             <Name>.i_xAutoReset</Name>
@@ -74430,25 +74463,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Type Namespace="PMPS">FB_TempSensor_FFO</Type>
         <Comment> Mirrors have two RTDs on the chin guard, Left and Right</Comment>
         <BitSize>109056</BitSize>
-        <BitOffs>77568</BitOffs>
+        <BitOffs>77632</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ffUpperCoatingRTemp</Name>
         <Type Namespace="PMPS">FB_TempSensor_FFO</Type>
         <BitSize>109056</BitSize>
-        <BitOffs>186624</BitOffs>
+        <BitOffs>186688</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ffLowerCoatingLTemp</Name>
         <Type Namespace="PMPS">FB_TempSensor_FFO</Type>
         <BitSize>109056</BitSize>
-        <BitOffs>295680</BitOffs>
+        <BitOffs>295744</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ffLowerCoatingRTemp</Name>
         <Type Namespace="PMPS">FB_TempSensor_FFO</Type>
         <BitSize>109056</BitSize>
-        <BitOffs>404736</BitOffs>
+        <BitOffs>404800</BitOffs>
       </SubItem>
       <SubItem>
         <Name>aDbStateParams</Name>
@@ -74458,25 +74491,25 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Elements>2</Elements>
         </ArrayInfo>
         <BitSize>5120</BitSize>
-        <BitOffs>513792</BitOffs>
+        <BitOffs>513856</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbGetCoatingBPs</Name>
         <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
         <BitSize>109440</BitSize>
-        <BitOffs>518912</BitOffs>
+        <BitOffs>518976</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ftReadJsonDocDone</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
         <BitSize>64</BitSize>
-        <BitOffs>628352</BitOffs>
+        <BitOffs>628416</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bBPsLoaded</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>628416</BitOffs>
+        <BitOffs>628480</BitOffs>
         <Default>
           <Bool>false</Bool>
         </Default>
@@ -74485,13 +74518,13 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>i</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>628432</BitOffs>
+        <BitOffs>628496</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sDevState</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>628448</BitOffs>
+        <BitOffs>628512</BitOffs>
         <Default>
           <String/>
         </Default>
@@ -74500,12 +74533,15 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Name>bInit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>629096</BitOffs>
+        <BitOffs>629160</BitOffs>
       </SubItem>
       <Properties>
         <Property>
           <Name>PouType</Name>
           <Value>FunctionBlock</Value>
+        </Property>
+        <Property>
+          <Name>contains_implicit_enum</Name>
         </Property>
       </Properties>
     </DataType>
@@ -74573,7 +74609,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>84475904</ByteSize>
+          <ByteSize>85852160</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K4</Name>
             <Comment>Better have your inputs and outputs!
@@ -74596,7 +74632,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>84475904</ByteSize>
+          <ByteSize>85852160</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K4</Name>
             <BitSize>192</BitSize>
@@ -74617,7 +74653,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>84475904</ByteSize>
+          <ByteSize>85852160</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K4</Name>
             <BitSize>10432</BitSize>
@@ -74715,19 +74751,19 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>84475904</ByteSize>
+          <ByteSize>85852160</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K4</Name>
             <Comment>PI Serial</Comment>
             <BitSize>109632</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialDriver</BaseType>
-            <BitOffs>638815264</BitOffs>
+            <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
+            <BitOffs>663686272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K4.M1K4_Pitch</Name>
             <Comment> Pitch Mechanism:</Comment>
             <BitSize>2496</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</BaseType>
+            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
             <Default>
               <SubItem>
                 <Name>.ReqPosLimHi</Name>
@@ -74755,7 +74791,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>664211392</BitOffs>
+            <BitOffs>663822272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -74811,20 +74847,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">32</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>2</ContextId>
-          <ByteSize>84475904</ByteSize>
-          <Symbol>
-            <Name>lcls_twincat_optics_nrw.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>638760832</BitOffs>
-          </Symbol>
+          <ByteSize>85852160</ByteSize>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
@@ -75449,132 +75472,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               </Property>
             </Properties>
             <BitOffs>640262016</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1K4.fbRunHOMS.bSTOEnable1</Name>
-            <Comment> STO Button</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>640558752</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1K4.fbRunHOMS.bSTOEnable2</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>640558760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1K4.fbRunHOMS.stYupEnc</Name>
-            <Comment> Encoders</Comment>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>640558784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1K4.fbRunHOMS.stYdwnEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>640558912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1K4.fbRunHOMS.stXupEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>640559040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1K4.fbRunHOMS.stXdwnEnc</Name>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>640559168</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1K4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>640559744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1K4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>640559872</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1K4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>640569216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.M1K4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-            <Comment> Connect to encoder "Position" input</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>ULINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>640569344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.bDreamEnable1</Name>
@@ -78109,149 +78006,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitOffs>662807649</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PRG_MR1K4_SOMS.fbCoolingPanel.fbFlow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662968544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K4_SOMS.fbCoolingPanel.fbPress_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662968864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR1K4_SOMS.fbCoolingPanel.fbFlow_2.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662969248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K4_KBO.fbCoolingPanel.fbFlow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662969760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR2K4_KBO.fbCoolingPanel.fbPress_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662970080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K4_KBO.fbCoolingPanel.fbFlow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662970592</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR3K4_KBO.fbCoolingPanel.fbPress_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662970912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K4_KBO.fbCoolingPanel.fbFlow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662971424</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR4K4_KBO.fbCoolingPanel.fbPress_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662971744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR5K4_KBO.fbCoolingPanel.fbFlow_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662972256</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PRG_MR5K4_KBO.fbCoolingPanel.fbPress_1.iRaw</Name>
-            <Comment> Connect this input to the terminal</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>662972576</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>GVL_M2K4_RTD.nM2K4US_RTD_1</Name>
             <Comment> M2K4 BENDER RTDs
  M2K4 US RTDs</Comment>
@@ -78292,6 +78046,301 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitOffs>662973296</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663685504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1K4.fbRunHOMS.bSTOEnable1</Name>
+            <Comment> STO Button</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663797344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1K4.fbRunHOMS.bSTOEnable2</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663797352</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1K4.fbRunHOMS.stYupEnc</Name>
+            <Comment> Encoders</Comment>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663797376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1K4.fbRunHOMS.stYdwnEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663797504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1K4.fbRunHOMS.stXupEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663797632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1K4.fbRunHOMS.stXdwnEnc</Name>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663797760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1K4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663798336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1K4.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663798464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1K4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663807808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1K4.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
+            <Comment> Connect to encoder "Position" input</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>ULINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663807936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K4_SOMS.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663817760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K4_SOMS.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663818080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR1K4_SOMS.fbCoolingPanel.fbFlow_2.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663818464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K4_KBO.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663818976</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR2K4_KBO.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663819296</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K4_KBO.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663819808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR3K4_KBO.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663820128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K4_KBO.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663820640</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR4K4_KBO.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663820960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR5K4_KBO.fbCoolingPanel.fbFlow_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663821472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PRG_MR5K4_KBO.fbCoolingPanel.fbPress_1.iRaw</Name>
+            <Comment> Connect this input to the terminal</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663821792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K4.M1K4_Pitch.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>663824704</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>GVL_M2K4_RTD.nM2K4US_RTD_3</Name>
             <BitSize>16</BitSize>
             <BaseType>INT</BaseType>
@@ -78329,19 +78378,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               </Property>
             </Properties>
             <BitOffs>664211376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K4.M1K4_Pitch.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>664213824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K4_RTD.nM2K4DS_RTD_2</Name>
@@ -78880,7 +78916,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673066440</BitOffs>
+            <BitOffs>683750472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingLTemp.bUnderrange</Name>
@@ -78892,7 +78928,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673066448</BitOffs>
+            <BitOffs>683750480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingLTemp.bOverrange</Name>
@@ -78904,7 +78940,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673066456</BitOffs>
+            <BitOffs>683750488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingLTemp.iRaw</Name>
@@ -78916,7 +78952,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673066464</BitOffs>
+            <BitOffs>683750496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingRTemp.bError</Name>
@@ -78940,7 +78976,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673175496</BitOffs>
+            <BitOffs>683859528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingRTemp.bUnderrange</Name>
@@ -78952,7 +78988,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673175504</BitOffs>
+            <BitOffs>683859536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingRTemp.bOverrange</Name>
@@ -78964,7 +79000,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673175512</BitOffs>
+            <BitOffs>683859544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingRTemp.iRaw</Name>
@@ -78976,7 +79012,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673175520</BitOffs>
+            <BitOffs>683859552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingLTemp.bError</Name>
@@ -79000,7 +79036,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673284552</BitOffs>
+            <BitOffs>683968584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingLTemp.bUnderrange</Name>
@@ -79012,7 +79048,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673284560</BitOffs>
+            <BitOffs>683968592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingLTemp.bOverrange</Name>
@@ -79024,7 +79060,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673284568</BitOffs>
+            <BitOffs>683968600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingLTemp.iRaw</Name>
@@ -79036,7 +79072,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673284576</BitOffs>
+            <BitOffs>683968608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingRTemp.bError</Name>
@@ -79060,7 +79096,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673393608</BitOffs>
+            <BitOffs>684077640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingRTemp.bUnderrange</Name>
@@ -79072,7 +79108,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673393616</BitOffs>
+            <BitOffs>684077648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingRTemp.bOverrange</Name>
@@ -79084,7 +79120,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673393624</BitOffs>
+            <BitOffs>684077656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingRTemp.iRaw</Name>
@@ -79096,7 +79132,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>673393632</BitOffs>
+            <BitOffs>684077664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.bError</Name>
@@ -79120,7 +79156,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674027656</BitOffs>
+            <BitOffs>684379656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.bUnderrange</Name>
@@ -79132,7 +79168,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674027664</BitOffs>
+            <BitOffs>684379664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.bOverrange</Name>
@@ -79144,7 +79180,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674027672</BitOffs>
+            <BitOffs>684379672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.iRaw</Name>
@@ -79156,7 +79192,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674027680</BitOffs>
+            <BitOffs>684379680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.bError</Name>
@@ -79180,7 +79216,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674136712</BitOffs>
+            <BitOffs>684488712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.bUnderrange</Name>
@@ -79192,7 +79228,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674136720</BitOffs>
+            <BitOffs>684488720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.bOverrange</Name>
@@ -79204,7 +79240,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674136728</BitOffs>
+            <BitOffs>684488728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.iRaw</Name>
@@ -79216,7 +79252,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674136736</BitOffs>
+            <BitOffs>684488736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.bError</Name>
@@ -79240,7 +79276,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674245768</BitOffs>
+            <BitOffs>684597768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.bUnderrange</Name>
@@ -79252,7 +79288,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674245776</BitOffs>
+            <BitOffs>684597776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.bOverrange</Name>
@@ -79264,7 +79300,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674245784</BitOffs>
+            <BitOffs>684597784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.iRaw</Name>
@@ -79276,7 +79312,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674245792</BitOffs>
+            <BitOffs>684597792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.bError</Name>
@@ -79300,7 +79336,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674354824</BitOffs>
+            <BitOffs>684706824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.bUnderrange</Name>
@@ -79312,7 +79348,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674354832</BitOffs>
+            <BitOffs>684706832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.bOverrange</Name>
@@ -79324,7 +79360,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674354840</BitOffs>
+            <BitOffs>684706840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.iRaw</Name>
@@ -79336,7 +79372,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674354848</BitOffs>
+            <BitOffs>684706848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.bError</Name>
@@ -79360,7 +79396,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674656776</BitOffs>
+            <BitOffs>685008840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.bUnderrange</Name>
@@ -79372,7 +79408,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674656784</BitOffs>
+            <BitOffs>685008848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.bOverrange</Name>
@@ -79384,7 +79420,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674656792</BitOffs>
+            <BitOffs>685008856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.iRaw</Name>
@@ -79396,7 +79432,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674656800</BitOffs>
+            <BitOffs>685008864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.bError</Name>
@@ -79420,7 +79456,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674765832</BitOffs>
+            <BitOffs>685117896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.bUnderrange</Name>
@@ -79432,7 +79468,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674765840</BitOffs>
+            <BitOffs>685117904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.bOverrange</Name>
@@ -79444,7 +79480,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674765848</BitOffs>
+            <BitOffs>685117912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.iRaw</Name>
@@ -79456,7 +79492,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674765856</BitOffs>
+            <BitOffs>685117920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.bError</Name>
@@ -79480,7 +79516,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674874888</BitOffs>
+            <BitOffs>685226952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.bUnderrange</Name>
@@ -79492,7 +79528,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674874896</BitOffs>
+            <BitOffs>685226960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.bOverrange</Name>
@@ -79504,7 +79540,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674874904</BitOffs>
+            <BitOffs>685226968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.iRaw</Name>
@@ -79516,7 +79552,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674874912</BitOffs>
+            <BitOffs>685226976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.bError</Name>
@@ -79540,7 +79576,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674983944</BitOffs>
+            <BitOffs>685336008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.bUnderrange</Name>
@@ -79552,7 +79588,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674983952</BitOffs>
+            <BitOffs>685336016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.bOverrange</Name>
@@ -79564,7 +79600,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674983960</BitOffs>
+            <BitOffs>685336024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.iRaw</Name>
@@ -79576,14 +79612,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>674983968</BitOffs>
+            <BitOffs>685336032</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">33</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>2</ContextId>
-          <ByteSize>84475904</ByteSize>
+          <ByteSize>85852160</ByteSize>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -80521,7 +80557,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>84475904</ByteSize>
+          <ByteSize>85852160</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -87645,135 +87681,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitOffs>638757888</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Constants.cPiezoRange</Name>
-            <Comment> From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
-            <Default>
-              <Value>60</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>638758176</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT</Name>
-            <Comment> default gantry tolerance in encoder counts = nm</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Default>
-              <Value>50000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>638758208</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Constants.cPiezoMaxVoltage</Name>
-            <Comment> in Volts</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>120</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>638758272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Constants.cPiezoMinVoltage</Name>
-            <Comment> in Volts</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LREAL</BaseType>
-            <Default>
-              <Value>-10</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>638758336</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TestStructs.TestPitch_LimitSwitches</Name>
-            <BitSize>2496</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.ReqPosLimHi</Name>
-                <Value>2000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.ReqPosLimLo</Name>
-                <Value>-2000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.diEncPosLimHi</Name>
-                <Value>10768330</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.diEncPosLimLo</Name>
-                <Value>8141680</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>638758400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Version.stLibVersion_lcls_twincat_optics_nrw</Name>
-            <BitSize>288</BitSize>
-            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.iMajor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iMinor</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iBuild</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.iRevision</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.nFlags</Name>
-                <Value>0</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sVersion</Name>
-                <String>0.0.0</String>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>const_non_replaced</Name>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>638760896</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_ControllerToolbox</Name>
             <BitSize>288</BitSize>
             <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
@@ -88054,52 +87961,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitOffs>640259520</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.M1K4</Name>
-            <Comment>        {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041-1000_M1K4_Bender]^STM Status^Status^Digital input 1;
-                                  .bLimitBackwardEnable:=TIIB[EL7041-1000_M1K4_Bender]^STM Status^Status^Digital input 2'}
-        {attribute 'pytmc' := '
-            pv: MR1K4:SOMS:MMS:BENDER
-        '}
-        M6 : ST_MotionStage := (fVelocity := 150.0, bPowerSelf:=TRUE); // M1K4 Bender
-        fbMotionStage_m6 : FB_MotionStage;
-</Comment>
-            <BitSize>20672</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">DUT_HOMS</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcLinkTo</Name>
-                <Value>.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K4_STO]^Channel 1^Input;
-                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K4_STO]^Channel 2^Input;
-                              .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K4_Yupdwn]^FB Inputs Channel 1^Position;
-                              .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K4_Yupdwn]^FB Inputs Channel 2^Position;
-                              .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K4_Xupdwn]^FB Inputs Channel 1^Position;
-                              .fbRunHOMS.stXdwnEnc.Count:=TIIB[EL5042_M1K4_Xupdwn]^FB Inputs Channel 2^Position</Value>
-              </Property>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: MR1K4:SOMS
-    </Value>
-              </Property>
-            </Properties>
-            <BitOffs>640557824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbYRMSErrorM1K4</Name>
-            <Comment> Encoder Arrays/RMS Watch:</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR1K4:SOMS:ENC:Y
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>640578496</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.fMaxYRMSErrorM1K4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -88110,20 +87971,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>640965440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbXRMSErrorM1K4</Name>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR1K4:SOMS:ENC:X
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>640965504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxXRMSErrorM1K4</Name>
@@ -88138,20 +87985,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitOffs>641352448</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fbPitchRMSErrorM1K4</Name>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR1K4:SOMS:ENC:PITCH
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>641352512</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.fMaxPitchRMSErrorM1K4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -88164,20 +87997,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitOffs>641739456</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fbBenderRMSErrorM1K4</Name>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR1K4:SOMS:ENC:BENDER
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>641739520</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.fMaxBenderRMSErrorM1K4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -88188,17 +88007,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>642126464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbBenderM1K4</Name>
-            <Comment> Piezo Pitch Control
-fbM1K4PitchControl : FB_PitchControl;
-bM1K4PitchDone : BOOL;
-bM1K4PitchBusy : BOOL;
- Bender Control</Comment>
-            <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Bender</BaseType>
-            <BitOffs>642126528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.nEncCntYdwnM1K4</Name>
@@ -89046,22 +88854,6 @@ PMPS State Stage; bPowerSelf:=False</Comment>
             <BitOffs>647669184</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fbXRMSErrorM2K4</Name>
-            <Comment> Encoder Arrays/RMS Watch:
-MR2K4 X ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR2K4:KBO:ENC:X
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>647967488</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.fMaxXRMSErrorM2K4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89072,21 +88864,6 @@ MR2K4 X ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>648354432</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbYRMSErrorM2K4</Name>
-            <Comment>MR2K4 Y ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR2K4:KBO:ENC:Y
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>648354496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxYRMSErrorM2K4</Name>
@@ -89101,21 +88878,6 @@ MR2K4 X ENC RMS</Comment>
             <BitOffs>648741440</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fbrYRMSErrorM2K4</Name>
-            <Comment>MR2K4 rY ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR2K4:KBO:ENC:PITCH
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>648741504</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.fMaxrYRMSErrorM2K4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89126,21 +88888,6 @@ MR2K4 X ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>649128448</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbBendUSRMSErrorM2K4</Name>
-            <Comment>MR2K4 US BENDER ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR2K4:KBO:ENC:BEND:US
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>649128512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxBendUSRMSErrorM2K4</Name>
@@ -89155,21 +88902,6 @@ MR2K4 X ENC RMS</Comment>
             <BitOffs>649515456</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fbBendDSRMSErrorM2K4</Name>
-            <Comment>MR2K4 DS BENDER ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR2K4:KBO:ENC:BEND:DS
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>649515520</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.fMaxBendDSRMSErrorM2K4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89180,21 +88912,6 @@ MR2K4 X ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>649902464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbXRMSErrorM3K4</Name>
-            <Comment>MR3K4 X ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR3K4:KBO:ENC:X
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>649902528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxXRMSErrorM3K4</Name>
@@ -89209,21 +88926,6 @@ MR2K4 X ENC RMS</Comment>
             <BitOffs>650289472</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fbYRMSErrorM3K4</Name>
-            <Comment>MR3K4 Y ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR3K4:KBO:ENC:Y
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>650289536</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.fMaxYRMSErrorM3K4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89234,21 +88936,6 @@ MR2K4 X ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>650676480</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbrXRMSErrorM3K4</Name>
-            <Comment>MR3K4 rX ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR3K4:KBO:ENC:PITCH
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>650676544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxrXRMSErrorM3K4</Name>
@@ -89263,21 +88950,6 @@ MR2K4 X ENC RMS</Comment>
             <BitOffs>651063488</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fbBendUSRMSErrorM3K4</Name>
-            <Comment>MR3K4 US BENDER ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR3K4:KBO:ENC:BEND:US
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>651063552</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.fMaxBendUSRMSErrorM3K4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89288,21 +88960,6 @@ MR2K4 X ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>651450496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbBendDSRMSErrorM3K4</Name>
-            <Comment>MR3K4 DS BENDER ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR3K4:KBO:ENC:BEND:DS
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>651450560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxBendDSRMSErrorM3K4</Name>
@@ -89317,21 +88974,6 @@ MR2K4 X ENC RMS</Comment>
             <BitOffs>651837504</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fbXRMSErrorM4K4</Name>
-            <Comment>MR4K4 X ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR4K4:KBO:ENC:X
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>651837568</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.fMaxXRMSErrorM4K4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89342,21 +88984,6 @@ MR2K4 X ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>652224512</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbYRMSErrorM4K4</Name>
-            <Comment>MR4K4 Y ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR4K4:KBO:ENC:Y
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>652224576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxYRMSErrorM4K4</Name>
@@ -89371,21 +88998,6 @@ MR2K4 X ENC RMS</Comment>
             <BitOffs>652611520</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fbZRMSErrorM4K4</Name>
-            <Comment>MR4K4 Z ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR4K4:KBO:ENC:Z
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>652611584</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.fMaxZRMSErrorM4K4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89396,21 +89008,6 @@ MR2K4 X ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>652998528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbPRMSErrorM4K4</Name>
-            <Comment>MR4K4 rX ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR4K4:KBO:ENC:PITCH
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>652998592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxPRMSErrorM4K4</Name>
@@ -89425,21 +89022,6 @@ MR2K4 X ENC RMS</Comment>
             <BitOffs>653385536</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fbXRMSErrorM5K4</Name>
-            <Comment>MR5K4 X ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR5K4:KBO:ENC:X
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>653385600</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.fMaxXRMSErrorM5K4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89450,21 +89032,6 @@ MR2K4 X ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>653772544</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbYRMSErrorM5K4</Name>
-            <Comment>MR5K4 Y ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR5K4:KBO:ENC:Y
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>653772608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxYRMSErrorM5K4</Name>
@@ -89479,21 +89046,6 @@ MR2K4 X ENC RMS</Comment>
             <BitOffs>654159552</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.fbZRMSErrorM5K4</Name>
-            <Comment>MR5K4 Z ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR5K4:KBO:ENC:Z
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>654159616</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>Main.fMaxZRMSErrorM5K4</Name>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
@@ -89504,21 +89056,6 @@ MR2K4 X ENC RMS</Comment>
             <BitSize>64</BitSize>
             <BaseType>LREAL</BaseType>
             <BitOffs>654546560</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Main.fbPRMSErrorM5K4</Name>
-            <Comment>MR5K4 rX ENC RMS</Comment>
-            <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-            pv: MR5K4:KBO:ENC:PITCH
-        </Value>
-              </Property>
-            </Properties>
-            <BitOffs>654546624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fMaxPRMSErrorM5K4</Name>
@@ -89765,7 +89302,7 @@ MR2K4 X ENC CNT</Comment>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-                pv: MR2K4:KBO:RTD:BEND:US:2
+                pv: MR2K4:KBO:RTD:CHIN:L
                 field: ASLO 0.1
                 field: EGU C
                 io: i
@@ -89817,7 +89354,7 @@ MR2K4 X ENC CNT</Comment>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-            pv: MR2K4:KBO:RTD:BEND:DS:2
+            pv: MR2K4:KBO:RTD:CHIN:R
             field: ASLO 0.1
             field: EGU C
             io: i
@@ -89869,7 +89406,7 @@ MR2K4 X ENC CNT</Comment>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-            pv: MR3K4:KBO:RTD:BEND:US:2
+            pv: MR3K4:KBO:RTD:CHIN:L
             field: ASLO 0.1
             field: EGU C
             io: i
@@ -89921,7 +89458,7 @@ MR2K4 X ENC CNT</Comment>
               <Property>
                 <Name>pytmc</Name>
                 <Value>
-            pv: MR3K4:KBO:RTD:BEND:DS:2
+            pv: MR3K4:KBO:RTD:CHIN:R
             field: ASLO 0.1
             field: EGU C
             io: i
@@ -90056,10 +89593,181 @@ MR2K4 X ENC CNT</Comment>
             <BitOffs>662942080</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>GVL_Constants.cPiezoRange</Name>
+            <Comment> From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>60</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>662986528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT</Name>
+            <Comment> default gantry tolerance in encoder counts = nm</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Default>
+              <Value>50000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>663682880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Constants.cPiezoMaxVoltage</Name>
+            <Comment> in Volts</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>120</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>663682944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Constants.cPiezoMinVoltage</Name>
+            <Comment> in Volts</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LREAL</BaseType>
+            <Default>
+              <Value>-10</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>663683008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_TestStructs.TestPitch_LimitSwitches</Name>
+            <BitSize>2496</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.ReqPosLimHi</Name>
+                <Value>2000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.ReqPosLimLo</Name>
+                <Value>-2000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.diEncPosLimHi</Name>
+                <Value>10768330</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.diEncPosLimLo</Name>
+                <Value>8141680</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>663683072</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Version.stLibVersion_lcls_twincat_optics</Name>
+            <BitSize>288</BitSize>
+            <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.iMajor</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iMinor</Name>
+                <Value>8</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iBuild</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.iRevision</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sVersion</Name>
+                <String>0.8.0</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>const_non_replaced</Name>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>663685568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.M1K4</Name>
+            <Comment>        {attribute 'TcLinkTo' := '.bLimitForwardEnable:=TIIB[EL7041-1000_M1K4_Bender]^STM Status^Status^Digital input 1;
+                                  .bLimitBackwardEnable:=TIIB[EL7041-1000_M1K4_Bender]^STM Status^Status^Digital input 2'}
+        {attribute 'pytmc' := '
+            pv: MR1K4:SOMS:MMS:BENDER
+        '}
+        M6 : ST_MotionStage := (fVelocity := 150.0, bPowerSelf:=TRUE); // M1K4 Bender
+        fbMotionStage_m6 : FB_MotionStage;
+</Comment>
+            <BitSize>20672</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">DUT_HOMS</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.fbRunHOMS.bSTOEnable1:=TIIB[EL1004_M1K4_STO]^Channel 1^Input;
+                              .fbRunHOMS.bSTOEnable2:=TIIB[EL1004_M1K4_STO]^Channel 2^Input;
+                              .fbRunHOMS.stYupEnc.Count:=TIIB[EL5042_M1K4_Yupdwn]^FB Inputs Channel 1^Position;
+                              .fbRunHOMS.stYdwnEnc.Count:=TIIB[EL5042_M1K4_Yupdwn]^FB Inputs Channel 2^Position;
+                              .fbRunHOMS.stXupEnc.Count:=TIIB[EL5042_M1K4_Xupdwn]^FB Inputs Channel 1^Position;
+                              .fbRunHOMS.stXdwnEnc.Count:=TIIB[EL5042_M1K4_Xupdwn]^FB Inputs Channel 2^Position</Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR1K4:SOMS
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>663796416</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbBenderM1K4</Name>
+            <Comment> Piezo Pitch Control
+fbM1K4PitchControl : FB_PitchControl;
+bM1K4PitchDone : BOOL;
+bM1K4PitchBusy : BOOL;
+ Bender Control</Comment>
+            <BitSize>128</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_Bender</BaseType>
+            <BitOffs>663817088</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>PRG_MR1K4_SOMS.fbCoolingPanel</Name>
             <Comment> M1K4 Flow Press Sensors</Comment>
             <BitSize>1216</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_2f1p</BaseType>
+            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_2f1p</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -90075,13 +89783,13 @@ MR2K4 X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>662968320</BitOffs>
+            <BitOffs>663817536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR2K4_KBO.fbCoolingPanel</Name>
             <Comment> M2K4 Flow Press Sensors</Comment>
             <BitSize>832</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
+            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -90096,13 +89804,13 @@ MR2K4 X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>662969536</BitOffs>
+            <BitOffs>663818752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR3K4_KBO.fbCoolingPanel</Name>
             <Comment> M3K4 Flow Press Sensors</Comment>
             <BitSize>832</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
+            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -90117,13 +89825,13 @@ MR2K4 X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>662970368</BitOffs>
+            <BitOffs>663819584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR4K4_KBO.fbCoolingPanel</Name>
             <Comment> MR4K4 Flow Press Sensors</Comment>
             <BitSize>832</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
+            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -90138,13 +89846,13 @@ MR2K4 X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>662971200</BitOffs>
+            <BitOffs>663820416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PRG_MR5K4_KBO.fbCoolingPanel</Name>
             <Comment> MR5K4 Flow Press Sensors</Comment>
             <BitSize>832</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
+            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -90159,7 +89867,7 @@ MR2K4 X ENC CNT</Comment>
     </Value>
               </Property>
             </Properties>
-            <BitOffs>662972032</BitOffs>
+            <BitOffs>663821248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K4_Constants.nYUP_ENC_REF</Name>
@@ -91538,6 +91246,334 @@ MR2K4 X ENC CNT</Comment>
             <BitOffs>666217120</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>Main.fbYRMSErrorM1K4</Name>
+            <Comment> Encoder Arrays/RMS Watch:</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR1K4:SOMS:ENC:Y
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>673221440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbXRMSErrorM1K4</Name>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR1K4:SOMS:ENC:X
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>673608320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbPitchRMSErrorM1K4</Name>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR1K4:SOMS:ENC:PITCH
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>673995200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbBenderRMSErrorM1K4</Name>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR1K4:SOMS:ENC:BENDER
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>674382080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbXRMSErrorM2K4</Name>
+            <Comment> Encoder Arrays/RMS Watch:
+MR2K4 X ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR2K4:KBO:ENC:X
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>674768960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbYRMSErrorM2K4</Name>
+            <Comment>MR2K4 Y ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR2K4:KBO:ENC:Y
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>677095680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbrYRMSErrorM2K4</Name>
+            <Comment>MR2K4 rY ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR2K4:KBO:ENC:PITCH
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>677482560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbBendUSRMSErrorM2K4</Name>
+            <Comment>MR2K4 US BENDER ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR2K4:KBO:ENC:BEND:US
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>677869440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbBendDSRMSErrorM2K4</Name>
+            <Comment>MR2K4 DS BENDER ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR2K4:KBO:ENC:BEND:DS
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>678256320</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbXRMSErrorM3K4</Name>
+            <Comment>MR3K4 X ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR3K4:KBO:ENC:X
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>678643200</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbYRMSErrorM3K4</Name>
+            <Comment>MR3K4 Y ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR3K4:KBO:ENC:Y
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>679030080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbrXRMSErrorM3K4</Name>
+            <Comment>MR3K4 rX ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR3K4:KBO:ENC:PITCH
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>679416960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbBendUSRMSErrorM3K4</Name>
+            <Comment>MR3K4 US BENDER ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR3K4:KBO:ENC:BEND:US
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>679803840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbBendDSRMSErrorM3K4</Name>
+            <Comment>MR3K4 DS BENDER ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR3K4:KBO:ENC:BEND:DS
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>680190720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbXRMSErrorM4K4</Name>
+            <Comment>MR4K4 X ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR4K4:KBO:ENC:X
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>680577600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbYRMSErrorM4K4</Name>
+            <Comment>MR4K4 Y ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR4K4:KBO:ENC:Y
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>680964480</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbZRMSErrorM4K4</Name>
+            <Comment>MR4K4 Z ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR4K4:KBO:ENC:Z
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>681351360</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbPRMSErrorM4K4</Name>
+            <Comment>MR4K4 rX ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR4K4:KBO:ENC:PITCH
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>681738240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbXRMSErrorM5K4</Name>
+            <Comment>MR5K4 X ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR5K4:KBO:ENC:X
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>682125120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbYRMSErrorM5K4</Name>
+            <Comment>MR5K4 Y ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR5K4:KBO:ENC:Y
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>682512000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbZRMSErrorM5K4</Name>
+            <Comment>MR5K4 Z ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR5K4:KBO:ENC:Z
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>682898880</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Main.fbPRMSErrorM5K4</Name>
+            <Comment>MR5K4 rX ENC RMS</Comment>
+            <BitSize>386880</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+            pv: MR5K4:KBO:ENC:PITCH
+        </Value>
+              </Property>
+            </Properties>
+            <BitOffs>683285760</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>P_StripeProtections.fbStripProtMR1K4</Name>
             <Comment>
 MR1K4 (RBV = MR1K4:SOMS:ENC:YUP:CNT_RBV)
@@ -91546,8 +91582,8 @@ Transition: 15998960 &lt; RBV &lt; 19998960: 0000_0000_0000_0000
 Silicon surface: RBV &gt;= 19998960: 0000_0000_0001_1110 (allow everything between 250eV and 450eV)
 From M. Seaberg
 </Comment>
-            <BitSize>629120</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_MirrorTwoCoatingProtection</BaseType>
+            <BitSize>629184</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_MirrorTwoCoatingProtection</BaseType>
             <Default>
               <SubItem>
                 <Name>.sDevName</Name>
@@ -91570,7 +91606,7 @@ From M. Seaberg
                 <String>B4C</String>
               </SubItem>
             </Default>
-            <BitOffs>672988672</BitOffs>
+            <BitOffs>683672640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR2K4</Name>
@@ -91581,8 +91617,8 @@ Transition: 6976835 &lt; RBV &lt; 7776781: 0000_0000_0000_0000
 Silicon surface: RBV &gt;= 7776781: 0000_0000_0001_1110 (allow everything below 250eV and 450eV)
 
  MR2K4 Mirror Chin Guard RTDs</Comment>
-            <BitSize>629120</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_MirrorTwoCoatingProtection</BaseType>
+            <BitSize>629184</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_MirrorTwoCoatingProtection</BaseType>
             <Default>
               <SubItem>
                 <Name>.sDevName</Name>
@@ -91609,9 +91645,24 @@ Silicon surface: RBV &gt;= 7776781: 0000_0000_0001_1110 (allow everything below 
               <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.ffUpperCoatingLTemp.iRaw := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Value;
+                              .ffUpperCoatingLTemp.bUnderrange := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Status^Underrange;
+                              .ffUpperCoatingLTemp.bOverrange := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Status^Overrange;
+                              .ffUpperCoatingLTemp.bError := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Status^Error;
+
                               .ffUpperCoatingRTemp.iRaw := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Value;
+                              .ffUpperCoatingRTemp.bUnderrange := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Status^Underrange;
+                              .ffUpperCoatingRTemp.bOverrange := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Status^Overrange;
+                              .ffUpperCoatingRTemp.bError := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Status^Error;
+
                               .ffLowerCoatingLTemp.iRaw := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Value;
+                              .ffLowerCoatingLTemp.bUnderrange := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Status^Underrange;
+                              .ffLowerCoatingLTemp.bOverrange := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Status^Overrange;
+                              .ffLowerCoatingLTemp.bError := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Status^Error;
+
                               .ffLowerCoatingRTemp.iRaw := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Value;
+                              .ffLowerCoatingRTemp.bUnderrange := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Status^Underrange;
+                              .ffLowerCoatingRTemp.bOverrange := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Status^Overrange;
+                              .ffLowerCoatingRTemp.bError := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Status^Error
     </Value>
               </Property>
               <Property>
@@ -91621,7 +91672,7 @@ Silicon surface: RBV &gt;= 7776781: 0000_0000_0001_1110 (allow everything below 
     </Value>
               </Property>
             </Properties>
-            <BitOffs>673949888</BitOffs>
+            <BitOffs>684301824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>P_StripeProtections.fbStripProtMR3K4</Name>
@@ -91632,8 +91683,8 @@ Transition: 4820000 &lt; ENC &lt; 5620000: 0000_0000_0000_0000
 Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything between 250eV and 450 eV)
 
  MR3K4 Mirror Chin Guard RTDs</Comment>
-            <BitSize>629120</BitSize>
-            <BaseType Namespace="lcls_twincat_optics_nrw">FB_MirrorTwoCoatingProtection</BaseType>
+            <BitSize>629184</BitSize>
+            <BaseType Namespace="lcls_twincat_optics">FB_MirrorTwoCoatingProtection</BaseType>
             <Default>
               <SubItem>
                 <Name>.sDevName</Name>
@@ -91660,9 +91711,25 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
               <Property>
                 <Name>TcLinkTo</Name>
                 <Value>.ffUpperCoatingLTemp.iRaw := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Value;
+                              .ffUpperCoatingLTemp.bUnderrange := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Status^Underrange;
+                              .ffUpperCoatingLTemp.bOverrange := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Status^Overrange;
+                              .ffUpperCoatingLTemp.bError := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Status^Error;
+
+
                               .ffUpperCoatingRTemp.iRaw := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Value;
+                              .ffUpperCoatingRTemp.bUnderrange := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Status^Underrange;
+                              .ffUpperCoatingRTemp.bOverrange := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Status^Overrange;
+                              .ffUpperCoatingRTemp.bError := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Status^Error;
+
                               .ffLowerCoatingLTemp.iRaw := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Value;
+                              .ffLowerCoatingLTemp.bUnderrange := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Status^Underrange;
+                              .ffLowerCoatingLTemp.bOverrange := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Status^Overrange;
+                              .ffLowerCoatingLTemp.bError := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Status^Error;
+
                               .ffLowerCoatingRTemp.iRaw := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Value;
+                              .ffLowerCoatingRTemp.bUnderrange := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Status^Underrange;
+                              .ffLowerCoatingRTemp.bOverrange := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Status^Overrange;
+                              .ffLowerCoatingRTemp.bError := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Status^Error
     </Value>
               </Property>
               <Property>
@@ -91672,14 +91739,14 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
     </Value>
               </Property>
             </Properties>
-            <BitOffs>674579008</BitOffs>
+            <BitOffs>684931008</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">36</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>2</ContextId>
-          <ByteSize>84475904</ByteSize>
+          <ByteSize>85852160</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -91765,11 +91832,11 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-09-11T16:33:39</Value>
+          <Value>2024-09-13T09:25:14</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>909312</Value>
+          <Value>913408</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>

--- a/lcls-plc-tmo-optics/tmo_optics/tmo_optics.tmc
+++ b/lcls-plc-tmo-optics/tmo_optics/tmo_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{B751D60F-6A36-0A2F-8955-4284BCC779DF}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{98D8E40B-E062-6F2F-8E5B-11A930123EFC}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -959,7 +959,7 @@
       <BaseType>STRING(255)</BaseType>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Name>
+      <Name Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Name>
       <BitSize>384</BitSize>
       <SubItem>
         <Name>tCtrlCycleTime</Name>
@@ -1033,7 +1033,7 @@
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">ST_PiezoAxis</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">ST_PiezoAxis</Name>
       <BitSize>2240</BitSize>
       <SubItem>
         <Name>sIdn</Name>
@@ -1162,7 +1162,7 @@
       </SubItem>
       <SubItem>
         <Name>stPIParams</Name>
-        <Type Namespace="lcls_twincat_optics.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
+        <Type Namespace="lcls_twincat_optics_nrw.Tc2_ControllerToolbox">ST_CTRL_PI_PARAMS</Type>
         <BitSize>384</BitSize>
         <BitOffs>1792</BitOffs>
         <Default>
@@ -2743,7 +2743,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_PI_E621_SerialTransaction</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialTransaction</Name>
       <BitSize>33248</BitSize>
       <SubItem>
         <Name>i_xExecute</Name>
@@ -3037,7 +3037,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialDriver</Name>
       <BitSize>109632</BitSize>
       <SubItem>
         <Name>i_xExecute</Name>
@@ -3140,7 +3140,7 @@
       </SubItem>
       <SubItem>
         <Name>iq_stPiezoAxis</Name>
-        <Type Namespace="lcls_twincat_optics" ReferenceTo="true">ST_PiezoAxis</Type>
+        <Type Namespace="lcls_twincat_optics_nrw" ReferenceTo="true">ST_PiezoAxis</Type>
         <BitSize>32</BitSize>
         <BitOffs>66976</BitOffs>
         <Properties>
@@ -3200,7 +3200,7 @@
       </SubItem>
       <SubItem>
         <Name>fbPITransaction</Name>
-        <Type Namespace="lcls_twincat_optics">FB_PI_E621_SerialTransaction</Type>
+        <Type Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialTransaction</Type>
         <BitSize>33248</BitSize>
         <BitOffs>67872</BitOffs>
       </SubItem>
@@ -3245,11 +3245,11 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">HOMS_PitchMechanism</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</Name>
       <BitSize>2496</BitSize>
       <SubItem>
         <Name>Piezo</Name>
-        <Type Namespace="lcls_twincat_optics">ST_PiezoAxis</Type>
+        <Type Namespace="lcls_twincat_optics_nrw">ST_PiezoAxis</Type>
         <Comment>Piezo</Comment>
         <BitSize>2240</BitSize>
         <BitOffs>0</BitOffs>
@@ -3472,31 +3472,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>83212152</GetCodeOffs>
+        <GetCodeOffs>83294004</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>83212188</GetCodeOffs>
+        <GetCodeOffs>83294040</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>83212196</GetCodeOffs>
+        <GetCodeOffs>83294048</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>83212176</GetCodeOffs>
+        <GetCodeOffs>83294028</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>83212192</GetCodeOffs>
+        <GetCodeOffs>83294044</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -4748,15 +4748,15 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>83212088</GetCodeOffs>
-        <SetCodeOffs>83212112</SetCodeOffs>
+        <GetCodeOffs>83293940</GetCodeOffs>
+        <SetCodeOffs>83293964</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>83212128</GetCodeOffs>
-        <SetCodeOffs>83212140</SetCodeOffs>
+        <GetCodeOffs>83293980</GetCodeOffs>
+        <SetCodeOffs>83293992</SetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -4997,31 +4997,31 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>83212244</GetCodeOffs>
+        <GetCodeOffs>83294096</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>83212224</GetCodeOffs>
+        <GetCodeOffs>83294076</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>83212312</GetCodeOffs>
+        <GetCodeOffs>83294164</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>83212316</GetCodeOffs>
+        <GetCodeOffs>83294168</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>83212272</GetCodeOffs>
+        <GetCodeOffs>83294124</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -5033,7 +5033,7 @@
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>83212320</GetCodeOffs>
+        <GetCodeOffs>83294172</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -5626,7 +5626,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>83212348</GetCodeOffs>
+        <GetCodeOffs>83294200</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -22225,14 +22225,14 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type>BOOL</Type>
         <Comment> is TRUE if a buffer is available.</Comment>
         <BitSize>8</BitSize>
-        <GetCodeOffs>83215256</GetCodeOffs>
+        <GetCodeOffs>83297108</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nBufferSize</Name>
         <Type>UDINT</Type>
         <Comment> current buffer size in bytes.</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>83215208</GetCodeOffs>
+        <GetCodeOffs>83297060</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="3">__getnBufferSize</Name>
@@ -23328,7 +23328,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>83215332</GetCodeOffs>
+        <GetCodeOffs>83297184</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>GetParameterByIdx</Name>
@@ -23987,7 +23987,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="lcls2_cc_lib.lcls_twincat_motion.Tc3_IPCDiag.Tc3_DynamicMemory">I_DynMem_Manager</Type>
         <Comment> dynamic memory manager used in the Tc3_IPCDiag library</Comment>
         <BitSize>32</BitSize>
-        <GetCodeOffs>83215388</GetCodeOffs>
+        <GetCodeOffs>83297240</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>Clear</Name>
@@ -46532,7 +46532,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_RunHOMS</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_RunHOMS</Name>
       <BitSize>20416</BitSize>
       <SubItem>
         <Name>nYupEncRef</Name>
@@ -46870,11 +46870,11 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">DUT_HOMS</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">DUT_HOMS</Name>
       <BitSize>20672</BitSize>
       <SubItem>
         <Name>fbRunHOMS</Name>
-        <Type Namespace="lcls_twincat_optics">FB_RunHOMS</Type>
+        <Type Namespace="lcls_twincat_optics_nrw">FB_RunHOMS</Type>
         <Comment> System initializiation</Comment>
         <BitSize>20416</BitSize>
         <BitOffs>0</BitOffs>
@@ -47477,7 +47477,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_RMSWatch</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</Name>
       <BitSize>386880</BitSize>
       <SubItem>
         <Name>fMaxRMSError</Name>
@@ -47715,7 +47715,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_Bender</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_Bender</Name>
       <BitSize>128</BitSize>
       <SubItem>
         <Name>stBender</Name>
@@ -49092,7 +49092,7 @@ External Setpoint Generation:
         <Name>nTimestamp</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>83218824</GetCodeOffs>
+        <GetCodeOffs>83300676</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcDisplayTypeGUID</Name>
@@ -49745,9 +49745,9 @@ External Setpoint Generation:
         <Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
         <Comment>Message or Alarm{Cleared,Confirmed,Raised} event information
 
-		Note that elements here do not follow the usual Hungarian notation / 
-		variable-type-prefixing naming convention due to the member names being
-		used directly in the generation of the JSON document.</Comment>
+        Note that elements here do not follow the usual Hungarian notation / 
+        variable-type-prefixing naming convention due to the member names being
+        used directly in the generation of the JSON document.</Comment>
         <BitSize>648</BitSize>
         <BitOffs>0</BitOffs>
         <Default>
@@ -49757,8 +49757,8 @@ External Setpoint Generation:
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: Schema
-		io: i
-		field: DESC Schema string</Value>
+        io: i
+        field: DESC Schema string</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -49771,8 +49771,8 @@ External Setpoint Generation:
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: Timestamp 
-		io: i
-		field: DESC Unix timestamp</Value>
+        io: i
+        field: DESC Unix timestamp</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -49785,8 +49785,8 @@ External Setpoint Generation:
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: Hostname 
-		io: i
-		field: DESC PLC Hostname</Value>
+        io: i
+        field: DESC PLC Hostname</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -49799,12 +49799,12 @@ External Setpoint Generation:
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: Severity
-		io: i
-		field: DESC TcEventSeverity	
-		field: ZRST Verbose
-		field: ONST Info
-		field: TWST Warning
-		field: THST Error</Value>
+        io: i
+        field: DESC TcEventSeverity	
+        field: ZRST Verbose
+        field: ONST Info
+        field: TWST Warning
+        field: THST Error</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -49817,8 +49817,8 @@ External Setpoint Generation:
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: MessageID
-		io: i
-		field: DESC TwinCAT Message ID</Value>
+        io: i
+        field: DESC TwinCAT Message ID</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -49831,8 +49831,8 @@ External Setpoint Generation:
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: EventClass
-		io: i
-		field: DESC TwinCAT Event class</Value>
+        io: i
+        field: DESC TwinCAT Event class</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -49845,7 +49845,7 @@ External Setpoint Generation:
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: Message
-		io: i</Value>
+        io: i</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -49860,7 +49860,7 @@ External Setpoint Generation:
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: Source
-		io: i</Value>
+        io: i</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -49875,8 +49875,8 @@ External Setpoint Generation:
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: EventType
-		io: i
-		field: DESC The event type</Value>
+        io: i
+        field: DESC The event type</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -49889,8 +49889,8 @@ External Setpoint Generation:
           <Property>
             <Name>plcAttribute_pytmc</Name>
             <Value>pv: MessageJSON
-		io: i
-		field: DESC Metadata with the message</Value>
+        io: i
+        field: DESC Metadata with the message</Value>
           </Property>
         </Properties>
       </SubItem>
@@ -51020,31 +51020,31 @@ External Setpoint Generation:
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>83218376</GetCodeOffs>
+        <GetCodeOffs>83300228</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>83218420</GetCodeOffs>
+        <GetCodeOffs>83300272</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>83218384</GetCodeOffs>
+        <GetCodeOffs>83300236</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>83218408</GetCodeOffs>
+        <GetCodeOffs>83300260</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>83218428</GetCodeOffs>
+        <GetCodeOffs>83300280</GetCodeOffs>
         <Properties>
           <Property>
             <Name>TcEncoding</Name>
@@ -60093,7 +60093,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</Name>
       <BitSize>832</BitSize>
       <SubItem>
         <Name>fFlow_1_val</Name>
@@ -60166,9 +60166,9 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_Axilon_Cooling_2f1p</Name>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_2f1p</Name>
       <BitSize>1216</BitSize>
-      <ExtendsType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</ExtendsType>
+      <ExtendsType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</ExtendsType>
       <SubItem>
         <Name>fFlow_2_val</Name>
         <Type>LREAL</Type>
@@ -60202,315 +60202,6 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         <Type Namespace="LCLS_General">FB_AnalogInput</Type>
         <BitSize>320</BitSize>
         <BitOffs>896</BitOffs>
-      </SubItem>
-      <Properties>
-        <Property>
-          <Name>PouType</Name>
-          <Value>FunctionBlock</Value>
-        </Property>
-      </Properties>
-    </DataType>
-    <DataType>
-      <Name Namespace="lcls_twincat_optics">FB_MirrorTwoCoatingProtection</Name>
-      <BitSize>192896</BitSize>
-      <SubItem>
-        <Name>nCurrentEncoderCount</Name>
-        <Type>UDINT</Type>
-        <Comment> Current encoder count</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>32</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>neVRange</Name>
-        <Type>DWORD</Type>
-        <Comment> Current ev range from stCurrentBeamParams</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>64</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sDevName</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Device name</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>96</BitOffs>
-        <Default>
-          <String/>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nUpperCoatingBoundary</Name>
-        <Type>UDINT</Type>
-        <Comment> Encoder count for upper boundary</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>768</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sUpperCoatingType</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Type of coating</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>800</BitOffs>
-        <Default>
-          <String/>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nLowerCoatingBoundary</Name>
-        <Type>UDINT</Type>
-        <Comment> Encoder count for lower boundary</Comment>
-        <BitSize>32</BitSize>
-        <BitOffs>1472</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>sLowerCoatingType</Name>
-        <Type>STRING(80)</Type>
-        <Comment> Type of coating</Comment>
-        <BitSize>648</BitSize>
-        <BitOffs>1504</BitOffs>
-        <Default>
-          <String/>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bAutoClear</Name>
-        <Type>BOOL</Type>
-        <Comment> Auto-clear these fast faults</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>2152</BitOffs>
-        <Default>
-          <Bool>true</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bReadPmpsDb</Name>
-        <Type>BOOL</Type>
-        <Comment> Trigger a re-read of the JSON Beam Parameters</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>2160</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>bUsePmpsDb</Name>
-        <Type>BOOL</Type>
-        <Comment> Set TRUE to lookup Beam Parameters via DB.</Comment>
-        <BitSize>8</BitSize>
-        <BitOffs>2168</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nUpperCoatingBitmask</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>2176</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>nLowerCoatingBitMask</Name>
-        <Type>DWORD</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>2208</BitOffs>
-        <Default>
-          <Value>0</Value>
-        </Default>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>FFO</Name>
-        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
-        <BitSize>32</BitSize>
-        <BitOffs>2240</BitOffs>
-        <Properties>
-          <Property>
-            <Name>ItemType</Name>
-            <Value>InOut</Value>
-          </Property>
-        </Properties>
-      </SubItem>
-      <SubItem>
-        <Name>ffUpperCoating</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>2272</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.i_xAutoReset</Name>
-            <Bool>false</Bool>
-          </SubItem>
-          <SubItem>
-            <Name>.i_TypeCode</Name>
-            <Value>1025</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.i_Desc</Name>
-            <String> mirror coating incompatible with beam photon energy</String>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>ffLowerCoating</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>27360</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.i_xAutoReset</Name>
-            <Bool>false</Bool>
-          </SubItem>
-          <SubItem>
-            <Name>.i_TypeCode</Name>
-            <Value>1025</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.i_Desc</Name>
-            <String> mirror coating incompatible with beam photon energy</String>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>ffBeamParamsNotLoaded</Name>
-        <Type Namespace="PMPS">FB_FastFault</Type>
-        <BitSize>25088</BitSize>
-        <BitOffs>52448</BitOffs>
-        <Default>
-          <SubItem>
-            <Name>.i_xAutoReset</Name>
-            <Bool>true</Bool>
-          </SubItem>
-          <SubItem>
-            <Name>.i_TypeCode</Name>
-            <Value>1160</Value>
-          </SubItem>
-          <SubItem>
-            <Name>.i_Desc</Name>
-            <String> mirror coating beam parameters not loaded</String>
-          </SubItem>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>aDbStateParams</Name>
-        <Type Namespace="PMPS">ST_DbStateParams</Type>
-        <ArrayInfo>
-          <LBound>0</LBound>
-          <Elements>2</Elements>
-        </ArrayInfo>
-        <BitSize>5120</BitSize>
-        <BitOffs>77536</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>fbGetCoatingBPs</Name>
-        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
-        <BitSize>109440</BitSize>
-        <BitOffs>82688</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>ftReadJsonDocDone</Name>
-        <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>64</BitSize>
-        <BitOffs>192128</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>bBPsLoaded</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192192</BitOffs>
-        <Default>
-          <Bool>false</Bool>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>i</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>192208</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>sDevState</Name>
-        <Type>STRING(80)</Type>
-        <BitSize>648</BitSize>
-        <BitOffs>192224</BitOffs>
-        <Default>
-          <String/>
-        </Default>
-      </SubItem>
-      <SubItem>
-        <Name>bInit</Name>
-        <Type>BOOL</Type>
-        <BitSize>8</BitSize>
-        <BitOffs>192872</BitOffs>
       </SubItem>
       <Properties>
         <Property>
@@ -74280,6 +73971,544 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         </Property>
       </Properties>
     </DataType>
+    <DataType>
+      <Name Namespace="PMPS">FB_TempSensor_FFO</Name>
+      <BitSize>109056</BitSize>
+      <ExtendsType Namespace="LCLS_General">FB_TempSensor</ExtendsType>
+      <SubItem>
+        <Name>fFaultThreshold</Name>
+        <Type>LREAL</Type>
+        <Comment>Faults when the threshold is reached. Trigger value.</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>256</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: FAULT_SP
+        io: input
+        field: EGU C
+        field: PREC 2
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>fHysteresis</Name>
+        <Type>LREAL</Type>
+        <Comment> percentage determining how far below the trigger value the fault should be released</Comment>
+        <BitSize>64</BitSize>
+        <BitOffs>320</BitOffs>
+        <Default>
+          <Value>1</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: FAULT_SP_HYS
+        io: input
+        field: EGU %
+        field: PREC 2
+    </Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDevName</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>384</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bVeto</Name>
+        <Type>BOOL</Type>
+        <Comment> This Fault will be will not trip the beam if the bVeto is TRUE</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>1032</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAutoReset</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1040</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>io_fbFFHWO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>1056</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sPath</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>1088</BitOffs>
+        <Properties>
+          <Property>
+            <Name>instance-path</Name>
+          </Property>
+          <Property>
+            <Name>noinit</Name>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bFAULT_OK</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1736</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>FFO</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>1760</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.i_Desc</Name>
+            <String>Fault occurs when the temprature trip point is reached</String>
+          </SubItem>
+          <SubItem>
+            <Name>.i_TypeCode</Name>
+            <Value>63232</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>rtRESET</Name>
+        <Type Namespace="Tc2_Standard">R_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>26848</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftFAULT</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>26912</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftConnected</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>26976</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbLogger</Name>
+        <Type Namespace="LCLS_General">FB_LogMessage</Type>
+        <BitSize>81984</BitSize>
+        <BitOffs>27072</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.eSubsystem</Name>
+            <EnumText>E_Subsystem.MPS</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.nMinTimeViolationAcceptable</Name>
+            <Value>10</Value>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <Action>
+        <Name>ACT_Logger</Name>
+      </Action>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_optics_nrw">FB_MirrorTwoCoatingProtection</Name>
+      <BitSize>629120</BitSize>
+      <SubItem>
+        <Name>nCurrentEncoderCount</Name>
+        <Type>UDINT</Type>
+        <Comment> Current encoder count</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>32</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>neVRange</Name>
+        <Type>DWORD</Type>
+        <Comment> Current ev range from stCurrentBeamParams</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>64</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sDevName</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Device name</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>96</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nUpperCoatingBoundary</Name>
+        <Type>UDINT</Type>
+        <Comment> Encoder count for upper boundary</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>768</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sUpperCoatingType</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Type of coating</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>800</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nLowerCoatingBoundary</Name>
+        <Type>UDINT</Type>
+        <Comment> Encoder count for lower boundary</Comment>
+        <BitSize>32</BitSize>
+        <BitOffs>1472</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>sLowerCoatingType</Name>
+        <Type>STRING(80)</Type>
+        <Comment> Type of coating</Comment>
+        <BitSize>648</BitSize>
+        <BitOffs>1504</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bAutoClear</Name>
+        <Type>BOOL</Type>
+        <Comment> Auto-clear these fast faults</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2152</BitOffs>
+        <Default>
+          <Bool>true</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bReadPmpsDb</Name>
+        <Type>BOOL</Type>
+        <Comment> Trigger a re-read of the JSON Beam Parameters</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2160</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bUsePmpsDb</Name>
+        <Type>BOOL</Type>
+        <Comment> Set TRUE to lookup Beam Parameters via DB.</Comment>
+        <BitSize>8</BitSize>
+        <BitOffs>2168</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nUpperCoatingBitmask</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2176</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>nLowerCoatingBitMask</Name>
+        <Type>DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2208</BitOffs>
+        <Default>
+          <Value>0</Value>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bMirrorTempFaults</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>2240</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Input</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>FFO</Name>
+        <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>2272</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>InOut</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>ffUpperCoating</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>2304</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.i_xAutoReset</Name>
+            <Bool>false</Bool>
+          </SubItem>
+          <SubItem>
+            <Name>.i_TypeCode</Name>
+            <Value>1025</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.i_Desc</Name>
+            <String> mirror coating incompatible with beam photon energy</String>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ffLowerCoating</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>27392</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.i_xAutoReset</Name>
+            <Bool>false</Bool>
+          </SubItem>
+          <SubItem>
+            <Name>.i_TypeCode</Name>
+            <Value>1025</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.i_Desc</Name>
+            <String> mirror coating incompatible with beam photon energy</String>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ffBeamParamsNotLoaded</Name>
+        <Type Namespace="PMPS">FB_FastFault</Type>
+        <BitSize>25088</BitSize>
+        <BitOffs>52480</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.i_xAutoReset</Name>
+            <Bool>true</Bool>
+          </SubItem>
+          <SubItem>
+            <Name>.i_TypeCode</Name>
+            <Value>1160</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.i_Desc</Name>
+            <String> mirror coating beam parameters not loaded</String>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>ffUpperCoatingLTemp</Name>
+        <Type Namespace="PMPS">FB_TempSensor_FFO</Type>
+        <Comment> Mirrors have two RTDs on the chin guard, Left and Right</Comment>
+        <BitSize>109056</BitSize>
+        <BitOffs>77568</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffUpperCoatingRTemp</Name>
+        <Type Namespace="PMPS">FB_TempSensor_FFO</Type>
+        <BitSize>109056</BitSize>
+        <BitOffs>186624</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffLowerCoatingLTemp</Name>
+        <Type Namespace="PMPS">FB_TempSensor_FFO</Type>
+        <BitSize>109056</BitSize>
+        <BitOffs>295680</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ffLowerCoatingRTemp</Name>
+        <Type Namespace="PMPS">FB_TempSensor_FFO</Type>
+        <BitSize>109056</BitSize>
+        <BitOffs>404736</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>aDbStateParams</Name>
+        <Type Namespace="PMPS">ST_DbStateParams</Type>
+        <ArrayInfo>
+          <LBound>0</LBound>
+          <Elements>2</Elements>
+        </ArrayInfo>
+        <BitSize>5120</BitSize>
+        <BitOffs>513792</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>fbGetCoatingBPs</Name>
+        <Type Namespace="PMPS">FB_JsonDocToSafeBP</Type>
+        <BitSize>109440</BitSize>
+        <BitOffs>518912</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>ftReadJsonDocDone</Name>
+        <Type Namespace="Tc2_Standard">F_TRIG</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>628352</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>bBPsLoaded</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>628416</BitOffs>
+        <Default>
+          <Bool>false</Bool>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>i</Name>
+        <Type>INT</Type>
+        <BitSize>16</BitSize>
+        <BitOffs>628432</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>sDevState</Name>
+        <Type>STRING(80)</Type>
+        <BitSize>648</BitSize>
+        <BitOffs>628448</BitOffs>
+        <Default>
+          <String/>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>bInit</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>629096</BitOffs>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>PouType</Name>
+          <Value>FunctionBlock</Value>
+        </Property>
+      </Properties>
+    </DataType>
   </DataTypes>
   <Modules>
     <Module GUID="{D7C1D1FD-2E7A-44CC-8FB4-AD582C20623F}" TcSmClass="TComPlcObjDef" TargetPlatform="TwinCAT RT (x86)">
@@ -74344,7 +74573,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>SerialIO Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>84213760</ByteSize>
+          <ByteSize>84475904</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComIn_M1K4</Name>
             <Comment>Better have your inputs and outputs!
@@ -74360,14 +74589,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665501504</BitOffs>
+            <BitOffs>666156032</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>SerialIO Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>84213760</ByteSize>
+          <ByteSize>84475904</ByteSize>
           <Symbol>
             <Name>GVL_SerialIO.Serial_stComOut_M1K4</Name>
             <BitSize>192</BitSize>
@@ -74381,14 +74610,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665501696</BitOffs>
+            <BitOffs>666156224</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>SerialIO Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>84213760</ByteSize>
+          <ByteSize>84475904</ByteSize>
           <Symbol>
             <Name>P_Serial_Com.fbSerialLineControl_EL6001_M1K4</Name>
             <BitSize>10432</BitSize>
@@ -74405,7 +74634,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663551744</BitOffs>
+            <BitOffs>664206336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_COM_Buffers.Serial_TXBuffer_M1K4</Name>
@@ -74416,7 +74645,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663554256</BitOffs>
+            <BitOffs>664208848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -74430,7 +74659,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665504192</BitOffs>
+            <BitOffs>666158752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_SerialIO</Name>
@@ -74444,7 +74673,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665509312</BitOffs>
+            <BitOffs>666160800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_SerialIO</Name>
@@ -74458,7 +74687,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665509344</BitOffs>
+            <BitOffs>666163904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__SerialIO</Name>
@@ -74479,26 +74708,26 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665509504</BitOffs>
+            <BitOffs>666164064</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">19</AreaNo>
           <Name>PiezoDriver Internal</Name>
           <ContextId>1</ContextId>
-          <ByteSize>84213760</ByteSize>
+          <ByteSize>84475904</ByteSize>
           <Symbol>
             <Name>PiezoSerial.fbE621SerialDriver_M1K4</Name>
             <Comment>PI Serial</Comment>
             <BitSize>109632</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_PI_E621_SerialDriver</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_PI_E621_SerialDriver</BaseType>
             <BitOffs>638815264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K4.M1K4_Pitch</Name>
             <Comment> Pitch Mechanism:</Comment>
             <BitSize>2496</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</BaseType>
             <Default>
               <SubItem>
                 <Name>.ReqPosLimHi</Name>
@@ -74526,7 +74755,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663556800</BitOffs>
+            <BitOffs>664211392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PiezoDriver</Name>
@@ -74540,7 +74769,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665509376</BitOffs>
+            <BitOffs>666163936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PiezoDriver</Name>
@@ -74554,7 +74783,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665509408</BitOffs>
+            <BitOffs>666163968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PiezoDriver</Name>
@@ -74575,16 +74804,16 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665510208</BitOffs>
+            <BitOffs>666164768</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="InputDst" CreateSymbols="true">32</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>2</ContextId>
-          <ByteSize>84213760</ByteSize>
+          <ByteSize>84475904</ByteSize>
           <Symbol>
-            <Name>lcls_twincat_optics.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
+            <Name>lcls_twincat_optics_nrw.GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
             <Comment>Raw encoder count</Comment>
             <BitSize>64</BitSize>
             <BaseType>LINT</BaseType>
@@ -78041,7 +78270,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663556768</BitOffs>
+            <BitOffs>662973280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K4_RTD.nM2K4US_RTD_2</Name>
@@ -78060,20 +78289,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663556784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_M1K4.M1K4_Pitch.diEncCnt</Name>
-            <Comment>Raw encoder count</Comment>
-            <BitSize>64</BitSize>
-            <BaseType>LINT</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>663559232</BitOffs>
+            <BitOffs>662973296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K4_RTD.nM2K4US_RTD_3</Name>
@@ -78092,7 +78308,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559552</BitOffs>
+            <BitOffs>664211360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K4_RTD.nM2K4DS_RTD_1</Name>
@@ -78112,7 +78328,20 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559568</BitOffs>
+            <BitOffs>664211376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_M1K4.M1K4_Pitch.diEncCnt</Name>
+            <Comment>Raw encoder count</Comment>
+            <BitSize>64</BitSize>
+            <BaseType>LINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>664213824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K4_RTD.nM2K4DS_RTD_2</Name>
@@ -78131,7 +78360,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559584</BitOffs>
+            <BitOffs>664214144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K4_RTD.nM2K4DS_RTD_3</Name>
@@ -78150,7 +78379,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559600</BitOffs>
+            <BitOffs>664214160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K4_RTD.nM3K4US_RTD_1</Name>
@@ -78171,7 +78400,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559808</BitOffs>
+            <BitOffs>664214176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K4_RTD.nM3K4US_RTD_2</Name>
@@ -78190,7 +78419,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559824</BitOffs>
+            <BitOffs>664214192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K4_RTD.nM3K4US_RTD_3</Name>
@@ -78209,7 +78438,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559840</BitOffs>
+            <BitOffs>664214400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K4_RTD.nM3K4DS_RTD_1</Name>
@@ -78229,7 +78458,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559856</BitOffs>
+            <BitOffs>664214416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K4_RTD.nM3K4DS_RTD_2</Name>
@@ -78248,7 +78477,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559872</BitOffs>
+            <BitOffs>664214432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K4_RTD.nM3K4DS_RTD_3</Name>
@@ -78267,7 +78496,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559888</BitOffs>
+            <BitOffs>664214448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Left_RTD.bError</Name>
@@ -78291,7 +78520,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663560328</BitOffs>
+            <BitOffs>664214856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Left_RTD.bUnderrange</Name>
@@ -78303,7 +78532,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663560336</BitOffs>
+            <BitOffs>664214864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Left_RTD.bOverrange</Name>
@@ -78315,7 +78544,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663560344</BitOffs>
+            <BitOffs>664214872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Left_RTD.iRaw</Name>
@@ -78327,7 +78556,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663560352</BitOffs>
+            <BitOffs>664214880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Right_RTD.bError</Name>
@@ -78351,7 +78580,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663560584</BitOffs>
+            <BitOffs>664215112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Right_RTD.bUnderrange</Name>
@@ -78363,7 +78592,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663560592</BitOffs>
+            <BitOffs>664215120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Right_RTD.bOverrange</Name>
@@ -78375,7 +78604,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663560600</BitOffs>
+            <BitOffs>664215128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Right_RTD.iRaw</Name>
@@ -78387,7 +78616,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663560608</BitOffs>
+            <BitOffs>664215136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Tail_RTD.bError</Name>
@@ -78411,7 +78640,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663560840</BitOffs>
+            <BitOffs>664215368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Tail_RTD.bUnderrange</Name>
@@ -78423,7 +78652,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663560848</BitOffs>
+            <BitOffs>664215376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Tail_RTD.bOverrange</Name>
@@ -78435,7 +78664,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663560856</BitOffs>
+            <BitOffs>664215384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Tail_RTD.iRaw</Name>
@@ -78447,7 +78676,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663560864</BitOffs>
+            <BitOffs>664215392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Left_RTD.bError</Name>
@@ -78471,7 +78700,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663561096</BitOffs>
+            <BitOffs>664215624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Left_RTD.bUnderrange</Name>
@@ -78483,7 +78712,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663561104</BitOffs>
+            <BitOffs>664215632</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Left_RTD.bOverrange</Name>
@@ -78495,7 +78724,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663561112</BitOffs>
+            <BitOffs>664215640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Left_RTD.iRaw</Name>
@@ -78507,7 +78736,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663561120</BitOffs>
+            <BitOffs>664215648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Right_RTD.bError</Name>
@@ -78531,7 +78760,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663561352</BitOffs>
+            <BitOffs>664215880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Right_RTD.bUnderrange</Name>
@@ -78543,7 +78772,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663561360</BitOffs>
+            <BitOffs>664215888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Right_RTD.bOverrange</Name>
@@ -78555,7 +78784,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663561368</BitOffs>
+            <BitOffs>664215896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Right_RTD.iRaw</Name>
@@ -78567,7 +78796,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663561376</BitOffs>
+            <BitOffs>664215904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Tail_RTD.bError</Name>
@@ -78591,7 +78820,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663561608</BitOffs>
+            <BitOffs>664216136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Tail_RTD.bUnderrange</Name>
@@ -78603,7 +78832,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663561616</BitOffs>
+            <BitOffs>664216144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Tail_RTD.bOverrange</Name>
@@ -78615,7 +78844,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663561624</BitOffs>
+            <BitOffs>664216152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Tail_RTD.iRaw</Name>
@@ -78627,14 +78856,734 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>663561632</BitOffs>
+            <BitOffs>664216160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingLTemp.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673066440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingLTemp.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673066448</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingLTemp.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673066456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingLTemp.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673066464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingRTemp.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673175496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingRTemp.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673175504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingRTemp.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673175512</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffUpperCoatingRTemp.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673175520</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingLTemp.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673284552</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingLTemp.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673284560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingLTemp.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673284568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingLTemp.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673284576</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingRTemp.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673393608</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingRTemp.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673393616</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingRTemp.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673393624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4.ffLowerCoatingRTemp.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>673393632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674027656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674027664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674027672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingLTemp.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674027680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674136712</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674136720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674136728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffUpperCoatingRTemp.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674136736</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674245768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674245776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674245784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingLTemp.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674245792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674354824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674354832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674354840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4.ffLowerCoatingRTemp.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674354848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674656776</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674656784</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674656792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingLTemp.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674656800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674765832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674765840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674765848</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffUpperCoatingRTemp.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674765856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674874888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674874896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674874904</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingLTemp.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674874912</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.bError</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674983944</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.bUnderrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674983952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.bOverrange</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674983960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4.ffLowerCoatingRTemp.iRaw</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcAddressType</Name>
+                <Value>Input</Value>
+              </Property>
+            </Properties>
+            <BitOffs>674983968</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">33</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>2</ContextId>
-          <ByteSize>84213760</ByteSize>
+          <ByteSize>84475904</ByteSize>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -79545,7 +80494,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>663561928</BitOffs>
+            <BitOffs>664216456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput2.q_xFastFaultOut</Name>
@@ -79565,14 +80514,14 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>664057224</BitOffs>
+            <BitOffs>664711752</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">35</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>2</ContextId>
-          <ByteSize>84213760</ByteSize>
+          <ByteSize>84475904</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
@@ -86758,7 +87707,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Symbol>
             <Name>GVL_TestStructs.TestPitch_LimitSwitches</Name>
             <BitSize>2496</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">HOMS_PitchMechanism</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">HOMS_PitchMechanism</BaseType>
             <Default>
               <SubItem>
                 <Name>.ReqPosLimHi</Name>
@@ -86785,7 +87734,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitOffs>638758400</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Version.stLibVersion_lcls_twincat_optics</Name>
+            <Name>Global_Version.stLibVersion_lcls_twincat_optics_nrw</Name>
             <BitSize>288</BitSize>
             <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
             <Default>
@@ -86795,7 +87744,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               </SubItem>
               <SubItem>
                 <Name>.iMinor</Name>
-                <Value>7</Value>
+                <Value>0</Value>
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
@@ -86811,7 +87760,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
               </SubItem>
               <SubItem>
                 <Name>.sVersion</Name>
-                <String>0.7.0</String>
+                <String>0.0.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -87115,7 +88064,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
         fbMotionStage_m6 : FB_MotionStage;
 </Comment>
             <BitSize>20672</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">DUT_HOMS</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">DUT_HOMS</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -87139,7 +88088,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <Name>Main.fbYRMSErrorM1K4</Name>
             <Comment> Encoder Arrays/RMS Watch:</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -87165,7 +88114,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Symbol>
             <Name>Main.fbXRMSErrorM1K4</Name>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -87191,7 +88140,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Symbol>
             <Name>Main.fbPitchRMSErrorM1K4</Name>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -87217,7 +88166,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
           <Symbol>
             <Name>Main.fbBenderRMSErrorM1K4</Name>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -87248,7 +88197,7 @@ bM1K4PitchDone : BOOL;
 bM1K4PitchBusy : BOOL;
  Bender Control</Comment>
             <BitSize>128</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_Bender</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Bender</BaseType>
             <BitOffs>642126528</BitOffs>
           </Symbol>
           <Symbol>
@@ -88101,7 +89050,7 @@ PMPS State Stage; bPowerSelf:=False</Comment>
             <Comment> Encoder Arrays/RMS Watch:
 MR2K4 X ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88128,7 +89077,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbYRMSErrorM2K4</Name>
             <Comment>MR2K4 Y ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88155,7 +89104,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbrYRMSErrorM2K4</Name>
             <Comment>MR2K4 rY ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88182,7 +89131,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbBendUSRMSErrorM2K4</Name>
             <Comment>MR2K4 US BENDER ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88209,7 +89158,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbBendDSRMSErrorM2K4</Name>
             <Comment>MR2K4 DS BENDER ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88236,7 +89185,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbXRMSErrorM3K4</Name>
             <Comment>MR3K4 X ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88263,7 +89212,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbYRMSErrorM3K4</Name>
             <Comment>MR3K4 Y ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88290,7 +89239,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbrXRMSErrorM3K4</Name>
             <Comment>MR3K4 rX ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88317,7 +89266,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbBendUSRMSErrorM3K4</Name>
             <Comment>MR3K4 US BENDER ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88344,7 +89293,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbBendDSRMSErrorM3K4</Name>
             <Comment>MR3K4 DS BENDER ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88371,7 +89320,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbXRMSErrorM4K4</Name>
             <Comment>MR4K4 X ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88398,7 +89347,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbYRMSErrorM4K4</Name>
             <Comment>MR4K4 Y ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88425,7 +89374,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbZRMSErrorM4K4</Name>
             <Comment>MR4K4 Z ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88452,7 +89401,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbPRMSErrorM4K4</Name>
             <Comment>MR4K4 rX ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88479,7 +89428,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbXRMSErrorM5K4</Name>
             <Comment>MR5K4 X ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88506,7 +89455,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbYRMSErrorM5K4</Name>
             <Comment>MR5K4 Y ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88533,7 +89482,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbZRMSErrorM5K4</Name>
             <Comment>MR5K4 Z ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -88560,7 +89509,7 @@ MR2K4 X ENC RMS</Comment>
             <Name>Main.fbPRMSErrorM5K4</Name>
             <Comment>MR5K4 rX ENC RMS</Comment>
             <BitSize>386880</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_RMSWatch</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_RMSWatch</BaseType>
             <Properties>
               <Property>
                 <Name>pytmc</Name>
@@ -89110,7 +90059,7 @@ MR2K4 X ENC CNT</Comment>
             <Name>PRG_MR1K4_SOMS.fbCoolingPanel</Name>
             <Comment> M1K4 Flow Press Sensors</Comment>
             <BitSize>1216</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_2f1p</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_2f1p</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -89132,7 +90081,7 @@ MR2K4 X ENC CNT</Comment>
             <Name>PRG_MR2K4_KBO.fbCoolingPanel</Name>
             <Comment> M2K4 Flow Press Sensors</Comment>
             <BitSize>832</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -89153,7 +90102,7 @@ MR2K4 X ENC CNT</Comment>
             <Name>PRG_MR3K4_KBO.fbCoolingPanel</Name>
             <Comment> M3K4 Flow Press Sensors</Comment>
             <BitSize>832</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -89174,7 +90123,7 @@ MR2K4 X ENC CNT</Comment>
             <Name>PRG_MR4K4_KBO.fbCoolingPanel</Name>
             <Comment> MR4K4 Flow Press Sensors</Comment>
             <BitSize>832</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -89195,7 +90144,7 @@ MR2K4 X ENC CNT</Comment>
             <Name>PRG_MR5K4_KBO.fbCoolingPanel</Name>
             <Comment> MR5K4 Flow Press Sensors</Comment>
             <BitSize>832</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_Axilon_Cooling_1f1p</BaseType>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_Axilon_Cooling_1f1p</BaseType>
             <Properties>
               <Property>
                 <Name>TcLinkTo</Name>
@@ -89213,109 +90162,6 @@ MR2K4 X ENC CNT</Comment>
             <BitOffs>662972032</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>P_StripeProtections.fbStripProtMR1K4</Name>
-            <Comment>
-MR1K4 (RBV = MR1K4:SOMS:ENC:YUP:CNT_RBV)
-B4C coating: RBV &lt;= 15998960: 1111_1111_1111_1000 (allow everything between 350eV and 2.3keV)
-Transition: 15998960 &lt; RBV &lt; 19998960: 0000_0000_0000_0000
-Silicon surface: RBV &gt;= 19998960: 0000_0000_0001_1110 (allow everything between 250eV and 450eV)
-From M. Seaberg
-</Comment>
-            <BitSize>192896</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_MirrorTwoCoatingProtection</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sDevName</Name>
-                <String>MR1K4:SOMS</String>
-              </SubItem>
-              <SubItem>
-                <Name>.nUpperCoatingBoundary</Name>
-                <Value>19998960</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sUpperCoatingType</Name>
-                <String>SILICON</String>
-              </SubItem>
-              <SubItem>
-                <Name>.nLowerCoatingBoundary</Name>
-                <Value>15998960</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sLowerCoatingType</Name>
-                <String>B4C</String>
-              </SubItem>
-            </Default>
-            <BitOffs>662973056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>P_StripeProtections.fbStripProtMR2K4</Name>
-            <Comment>
-MR2K4 (RBV = MR2K4:KBO:ENC:Y:CNT_RBV)
-B4C coating: RBV &lt;= 6976835: 1111_1111_1111_1000 (allow everything between 350eV and 2.3keV)
-Transition: 6976835 &lt; RBV &lt; 7776781: 0000_0000_0000_0000
-Silicon surface: RBV &gt;= 7776781: 0000_0000_0001_1110 (allow everything below 250eV and 450eV)
-</Comment>
-            <BitSize>192896</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_MirrorTwoCoatingProtection</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sDevName</Name>
-                <String>MR2K4:KBO</String>
-              </SubItem>
-              <SubItem>
-                <Name>.nUpperCoatingBoundary</Name>
-                <Value>7776781</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sUpperCoatingType</Name>
-                <String>SILICON</String>
-              </SubItem>
-              <SubItem>
-                <Name>.nLowerCoatingBoundary</Name>
-                <Value>6976835</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sLowerCoatingType</Name>
-                <String>B4C</String>
-              </SubItem>
-            </Default>
-            <BitOffs>663165952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>P_StripeProtections.fbStripProtMR3K4</Name>
-            <Comment>
-MR3K4 (RBV = MR3K4:KBO:ENC:X:CNT_RBV)
-B4C coating: RBV &gt;= 5620000: 1111_1111_1111_1000 (allow everything between 350eV and 2.3keV)
-Transition: 4820000 &lt; ENC &lt; 5620000: 0000_0000_0000_0000
-Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything between 250eV and 450 eV)
-</Comment>
-            <BitSize>192896</BitSize>
-            <BaseType Namespace="lcls_twincat_optics">FB_MirrorTwoCoatingProtection</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.sDevName</Name>
-                <String>MR3K4:KBO</String>
-              </SubItem>
-              <SubItem>
-                <Name>.nUpperCoatingBoundary</Name>
-                <Value>5620000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sUpperCoatingType</Name>
-                <String>B4C</String>
-              </SubItem>
-              <SubItem>
-                <Name>.nLowerCoatingBoundary</Name>
-                <Value>4820000</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.sLowerCoatingType</Name>
-                <String>SILICON</String>
-              </SubItem>
-            </Default>
-            <BitOffs>663358848</BitOffs>
-          </Symbol>
-          <Symbol>
             <Name>GVL_M1K4_Constants.nYUP_ENC_REF</Name>
             <Comment> Encoder reference values in counts = nm</Comment>
             <BitSize>64</BitSize>
@@ -89328,7 +90174,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559296</BitOffs>
+            <BitOffs>664213888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K4_Constants.nYDWN_ENC_REF</Name>
@@ -89342,7 +90188,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559360</BitOffs>
+            <BitOffs>664213952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K4_Constants.nXUP_ENC_REF</Name>
@@ -89356,7 +90202,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559424</BitOffs>
+            <BitOffs>664214016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M1K4_Constants.nXDWN_ENC_REF</Name>
@@ -89370,7 +90216,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559488</BitOffs>
+            <BitOffs>664214080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K4_Constants.nM2K4X_ENC_REF</Name>
@@ -89385,7 +90231,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559616</BitOffs>
+            <BitOffs>664214208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K4_Constants.nM2K4Y_ENC_REF</Name>
@@ -89399,7 +90245,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559680</BitOffs>
+            <BitOffs>664214272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M2K4_Constants.nM2K4rY_ENC_REF</Name>
@@ -89413,52 +90259,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559744</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>663559912</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>false</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>663559920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bFPUSupport</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Bool>true</Bool>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>663559928</BitOffs>
+            <BitOffs>664214336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K4_Constants.nM3K4X_ENC_REF</Name>
@@ -89473,7 +90274,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663559936</BitOffs>
+            <BitOffs>664214464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K4_Constants.nM3K4Y_ENC_REF</Name>
@@ -89487,7 +90288,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663560000</BitOffs>
+            <BitOffs>664214528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M3K4_Constants.nM3K4rX_ENC_REF</Name>
@@ -89501,7 +90302,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663560064</BitOffs>
+            <BitOffs>664214592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Left_RTD</Name>
@@ -89528,7 +90329,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663560128</BitOffs>
+            <BitOffs>664214656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Right_RTD</Name>
@@ -89554,7 +90355,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663560384</BitOffs>
+            <BitOffs>664214912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M4K4_RTD.nM4K4_Chin_Tail_RTD</Name>
@@ -89580,7 +90381,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663560640</BitOffs>
+            <BitOffs>664215168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Left_RTD</Name>
@@ -89607,7 +90408,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663560896</BitOffs>
+            <BitOffs>664215424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Right_RTD</Name>
@@ -89633,7 +90434,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663561152</BitOffs>
+            <BitOffs>664215680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_M5K4_RTD.nM5K4_Chin_Tail_RTD</Name>
@@ -89659,7 +90460,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663561408</BitOffs>
+            <BitOffs>664215936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput1</Name>
@@ -89691,7 +90492,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>663561664</BitOffs>
+            <BitOffs>664216192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_FastFaultOutput2</Name>
@@ -89723,7 +90524,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>664056960</BitOffs>
+            <BitOffs>664711488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_fbArbiter1</Name>
@@ -89744,7 +90545,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>664552256</BitOffs>
+            <BitOffs>665206784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_PMPS.g_fbArbiter2</Name>
@@ -89765,7 +90566,22 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665026880</BitOffs>
+            <BitOffs>665681408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bLittleEndian</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>666156424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -89795,7 +90611,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665501888</BitOffs>
+            <BitOffs>666156432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -89825,7 +90641,37 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665501952</BitOffs>
+            <BitOffs>666156496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bSimulationMode</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>666156560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bFPUSupport</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>666156568</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -89840,7 +90686,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665502016</BitOffs>
+            <BitOffs>666156576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -89855,7 +90701,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665502032</BitOffs>
+            <BitOffs>666156592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -89870,7 +90716,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665502048</BitOffs>
+            <BitOffs>666156608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -89885,7 +90731,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665502080</BitOffs>
+            <BitOffs>666156640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bMulticoreSupport</Name>
@@ -89899,7 +90745,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665502112</BitOffs>
+            <BitOffs>666156672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -90020,7 +90866,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665502144</BitOffs>
+            <BitOffs>666156704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -90038,7 +90884,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665506240</BitOffs>
+            <BitOffs>666160832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -90052,7 +90898,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665509440</BitOffs>
+            <BitOffs>666164000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -90066,7 +90912,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665509472</BitOffs>
+            <BitOffs>666164032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -90087,7 +90933,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665510912</BitOffs>
+            <BitOffs>666165472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcSystemEventClass</Name>
@@ -90159,7 +91005,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665528640</BitOffs>
+            <BitOffs>666183200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcGeneralAdsEventClass</Name>
@@ -90231,7 +91077,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665528768</BitOffs>
+            <BitOffs>666183328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRouterEventClass</Name>
@@ -90303,7 +91149,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665528896</BitOffs>
+            <BitOffs>666183456</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcRTimeEventClass</Name>
@@ -90375,7 +91221,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665529024</BitOffs>
+            <BitOffs>666183584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.Win32EventClass</Name>
@@ -90447,7 +91293,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665529152</BitOffs>
+            <BitOffs>666183712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.LCLSGeneralEventClass</Name>
@@ -90519,7 +91365,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665529280</BitOffs>
+            <BitOffs>666183840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagEventClass</Name>
@@ -90591,7 +91437,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665529408</BitOffs>
+            <BitOffs>666184224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENT_CLASSES.TcIPCDiagPlcApiEventClass</Name>
@@ -90663,7 +91509,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665529536</BitOffs>
+            <BitOffs>666184352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -90689,14 +91535,151 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>665562560</BitOffs>
+            <BitOffs>666217120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR1K4</Name>
+            <Comment>
+MR1K4 (RBV = MR1K4:SOMS:ENC:YUP:CNT_RBV)
+B4C coating: RBV &lt;= 15998960: 1111_1111_1111_1000 (allow everything between 350eV and 2.3keV)
+Transition: 15998960 &lt; RBV &lt; 19998960: 0000_0000_0000_0000
+Silicon surface: RBV &gt;= 19998960: 0000_0000_0001_1110 (allow everything between 250eV and 450eV)
+From M. Seaberg
+</Comment>
+            <BitSize>629120</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_MirrorTwoCoatingProtection</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sDevName</Name>
+                <String>MR1K4:SOMS</String>
+              </SubItem>
+              <SubItem>
+                <Name>.nUpperCoatingBoundary</Name>
+                <Value>19998960</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sUpperCoatingType</Name>
+                <String>SILICON</String>
+              </SubItem>
+              <SubItem>
+                <Name>.nLowerCoatingBoundary</Name>
+                <Value>15998960</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sLowerCoatingType</Name>
+                <String>B4C</String>
+              </SubItem>
+            </Default>
+            <BitOffs>672988672</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR2K4</Name>
+            <Comment>
+MR2K4 (RBV = MR2K4:KBO:ENC:Y:CNT_RBV)
+B4C coating: RBV &lt;= 6976835: 1111_1111_1111_1000 (allow everything between 350eV and 2.3keV)
+Transition: 6976835 &lt; RBV &lt; 7776781: 0000_0000_0000_0000
+Silicon surface: RBV &gt;= 7776781: 0000_0000_0001_1110 (allow everything below 250eV and 450eV)
+
+ MR2K4 Mirror Chin Guard RTDs</Comment>
+            <BitSize>629120</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_MirrorTwoCoatingProtection</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sDevName</Name>
+                <String>MR2K4:KBO</String>
+              </SubItem>
+              <SubItem>
+                <Name>.nUpperCoatingBoundary</Name>
+                <Value>7776781</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sUpperCoatingType</Name>
+                <String>SILICON</String>
+              </SubItem>
+              <SubItem>
+                <Name>.nLowerCoatingBoundary</Name>
+                <Value>6976835</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sLowerCoatingType</Name>
+                <String>B4C</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.ffUpperCoatingLTemp.iRaw := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Value;
+                              .ffUpperCoatingRTemp.iRaw := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Value;
+                              .ffLowerCoatingLTemp.iRaw := TIIB[EL3202-0010_M2K4US1_M2K4US2]^RTD Inputs Channel 2^Value;
+                              .ffLowerCoatingRTemp.iRaw := TIIB[EL3202-0010_M2K4DS2_M2K4DS3]^RTD Inputs Channel 1^Value;
+    </Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR2K4:KBO
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>673949888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>P_StripeProtections.fbStripProtMR3K4</Name>
+            <Comment>
+MR3K4 (RBV = MR3K4:KBO:ENC:X:CNT_RBV)
+B4C coating: RBV &gt;= 5620000: 1111_1111_1111_1000 (allow everything between 350eV and 2.3keV)
+Transition: 4820000 &lt; ENC &lt; 5620000: 0000_0000_0000_0000
+Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything between 250eV and 450 eV)
+
+ MR3K4 Mirror Chin Guard RTDs</Comment>
+            <BitSize>629120</BitSize>
+            <BaseType Namespace="lcls_twincat_optics_nrw">FB_MirrorTwoCoatingProtection</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.sDevName</Name>
+                <String>MR3K4:KBO</String>
+              </SubItem>
+              <SubItem>
+                <Name>.nUpperCoatingBoundary</Name>
+                <Value>5620000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sUpperCoatingType</Name>
+                <String>B4C</String>
+              </SubItem>
+              <SubItem>
+                <Name>.nLowerCoatingBoundary</Name>
+                <Value>4820000</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.sLowerCoatingType</Name>
+                <String>SILICON</String>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcLinkTo</Name>
+                <Value>.ffUpperCoatingLTemp.iRaw := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Value;
+                              .ffUpperCoatingRTemp.iRaw := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Value;
+                              .ffLowerCoatingLTemp.iRaw := TIIB[EL3202-0010_M3K4US1_M3K4US2]^RTD Inputs Channel 2^Value;
+                              .ffLowerCoatingRTemp.iRaw := TIIB[EL3202-0010_M3K4DS2_M3K4DS3]^RTD Inputs Channel 1^Value;
+    </Value>
+              </Property>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: MR3K4:KBO
+    </Value>
+              </Property>
+            </Properties>
+            <BitOffs>674579008</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">36</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>2</ContextId>
-          <ByteSize>84213760</ByteSize>
+          <ByteSize>84475904</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -90782,15 +91765,15 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2024-06-26T15:36:59</Value>
+          <Value>2024-09-11T16:33:39</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>905216</Value>
+          <Value>909312</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>82915328</Value>
+          <Value>83079168</Value>
         </Property>
       </Properties>
     </Module>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Upgraded lcls-twincat-optics 0.7.0 -> 0.8.0
- Updated MR2/3K4 Chin Guard RTD names
- Enabled mirror reactive temperature faulting for both.
- This amounts to lots of TC links to `P_StripeProtections` FBs.

- This PR make MR2/3K4 mirror fault based on a threshold value defined in the PMPS database.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- TMO wants reactive temp faulting on KB1 mirrors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Running on the PLC, checked function blocks online, forced RTD values on each piece of IO above the threshold, watched fault condition trigger/release.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
https://jira.slac.stanford.edu/browse/ECS-3630
## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
