### PR TITLE
removing tf5020 license to make it work

### DIFF
--- a/lcls-plc-tmo-optics.sln
+++ b/lcls-plc-tmo-optics.sln
@@ -1,11 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# TcXaeShell Solution File, Format Version 11.00
+VisualStudioVersion = 15.0.28307.1300
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{B1E792BE-AA5F-4E3C-8C82-674BF9C0715B}") = "lcls-plc-tmo-optics", "lcls-plc-tmo-optics\lcls-plc-tmo-optics.tsproj", "{469D9277-D01A-45EE-A69D-357039FEE32B}"
-EndProject
-Project("{FD9F1D59-E000-42F3-8744-88DE1BE93C06}") = "lcls-plc-tmo-optics_scope", "lcls-plc-tmo-optics_scope\lcls-plc-tmo-optics_scope.tcmproj", "{F76DA610-F06F-462A-8A6E-F0E93A3A7726}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,14 +33,6 @@ Global
 		{469D9277-D01A-45EE-A69D-357039FEE32B}.Release|TwinCAT RT (x64).Build.0 = Release|TwinCAT RT (x64)
 		{469D9277-D01A-45EE-A69D-357039FEE32B}.Release|TwinCAT RT (x86).ActiveCfg = Release|TwinCAT RT (x86)
 		{469D9277-D01A-45EE-A69D-357039FEE32B}.Release|TwinCAT RT (x86).Build.0 = Release|TwinCAT RT (x86)
-		{F76DA610-F06F-462A-8A6E-F0E93A3A7726}.Debug|TwinCAT CE7 (ARMV7).ActiveCfg = Debug|TwinCAT CE7 (ARMV7)
-		{F76DA610-F06F-462A-8A6E-F0E93A3A7726}.Debug|TwinCAT OS (ARMT2).ActiveCfg = Debug|TwinCAT OS (ARMT2)
-		{F76DA610-F06F-462A-8A6E-F0E93A3A7726}.Debug|TwinCAT RT (x64).ActiveCfg = Debug|TwinCAT RT (x64)
-		{F76DA610-F06F-462A-8A6E-F0E93A3A7726}.Debug|TwinCAT RT (x86).ActiveCfg = Debug|TwinCAT RT (x86)
-		{F76DA610-F06F-462A-8A6E-F0E93A3A7726}.Release|TwinCAT CE7 (ARMV7).ActiveCfg = Release|TwinCAT CE7 (ARMV7)
-		{F76DA610-F06F-462A-8A6E-F0E93A3A7726}.Release|TwinCAT OS (ARMT2).ActiveCfg = Release|TwinCAT OS (ARMT2)
-		{F76DA610-F06F-462A-8A6E-F0E93A3A7726}.Release|TwinCAT RT (x64).ActiveCfg = Release|TwinCAT RT (x64)
-		{F76DA610-F06F-462A-8A6E-F0E93A3A7726}.Release|TwinCAT RT (x86).ActiveCfg = Release|TwinCAT RT (x86)
 		{7FA5AD82-8B94-448C-8921-86A608467E2A}.Debug|TwinCAT CE7 (ARMV7).ActiveCfg = Debug|TwinCAT CE7 (ARMV7)
 		{7FA5AD82-8B94-448C-8921-86A608467E2A}.Debug|TwinCAT CE7 (ARMV7).Build.0 = Debug|TwinCAT CE7 (ARMV7)
 		{7FA5AD82-8B94-448C-8921-86A608467E2A}.Debug|TwinCAT OS (ARMT2).ActiveCfg = Debug|TwinCAT OS (ARMT2)
@@ -62,5 +52,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {55573800-110F-4C19-B78A-6757C04D7479}
 	EndGlobalSection
 EndGlobal

--- a/lcls-plc-tmo-optics/_Config/PLC/tmo_optics.xti
+++ b/lcls-plc-tmo-optics/_Config/PLC/tmo_optics.xti
@@ -1349,7 +1349,7 @@ External Setpoint Generation:
 		</DataType>
 	</DataTypes>
 	<Project GUID="{7FA5AD82-8B94-448C-8921-86A608467E2A}" Name="tmo_optics" PrjFilePath="..\..\tmo_optics\tmo_optics.plcproj" TmcFilePath="..\..\tmo_optics\tmo_optics.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_optics\tmo_optics.tmc" TmcHash="{9C838E67-D00C-0196-A25B-A6024E89C10D}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="tmo_optics\tmo_optics.tmc" TmcHash="{3DF987F6-C15A-5B4B-4870-3DE72CC53B1C}">
 			<Name>tmo_optics Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -3625,19 +3625,19 @@ External Setpoint Generation:
 					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
-					<Name>Main.M25_position_UDINT</Name>
+					<Name>Main.nM25Position</Name>
 					<Type>UDINT</Type>
 				</Var>
 				<Var>
-					<Name>Main.M26_position_UDINT</Name>
+					<Name>Main.nM26Position</Name>
 					<Type>UDINT</Type>
 				</Var>
 				<Var>
-					<Name>Main.M27_position_UDINT</Name>
+					<Name>Main.nM27Position</Name>
 					<Type>UDINT</Type>
 				</Var>
 				<Var>
-					<Name>Main.M28_position_UDINT</Name>
+					<Name>Main.nM28Position</Name>
 					<Type>UDINT</Type>
 				</Var>
 				<Var>
@@ -4277,22 +4277,22 @@ External Setpoint Generation:
 			<OwnerB Name="TINC^NC-Task 1 SAF^Axes^SL2K4_BOTTOM">
 				<Link VarA="PlcTask Inputs^Main.M26.Axis.NcToPlc" VarB="Outputs^ToPlc"/>
 				<Link VarA="PlcTask Outputs^Main.M26.Axis.PlcToNc" VarB="Inputs^FromPlc"/>
-				<Link VarA="PlcTask Outputs^Main.M26_position_UDINT" VarB="Enc^Inputs^In^nDataIn1" AutoLink="true"/>
+				<Link VarA="PlcTask Outputs^Main.nM26Position" VarB="Enc^Inputs^In^nDataIn1" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TINC^NC-Task 1 SAF^Axes^SL2K4_NORTH">
 				<Link VarA="PlcTask Inputs^Main.M27.Axis.NcToPlc" VarB="Outputs^ToPlc"/>
 				<Link VarA="PlcTask Outputs^Main.M27.Axis.PlcToNc" VarB="Inputs^FromPlc"/>
-				<Link VarA="PlcTask Outputs^Main.M27_position_UDINT" VarB="Enc^Inputs^In^nDataIn1" AutoLink="true"/>
+				<Link VarA="PlcTask Outputs^Main.nM27Position" VarB="Enc^Inputs^In^nDataIn1" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TINC^NC-Task 1 SAF^Axes^SL2K4_SOUTH">
 				<Link VarA="PlcTask Inputs^Main.M28.Axis.NcToPlc" VarB="Outputs^ToPlc"/>
 				<Link VarA="PlcTask Outputs^Main.M28.Axis.PlcToNc" VarB="Inputs^FromPlc"/>
-				<Link VarA="PlcTask Outputs^Main.M28_position_UDINT" VarB="Enc^Inputs^In^nDataIn1" AutoLink="true"/>
+				<Link VarA="PlcTask Outputs^Main.nM28Position" VarB="Enc^Inputs^In^nDataIn1" AutoLink="true"/>
 			</OwnerB>
 			<OwnerB Name="TINC^NC-Task 1 SAF^Axes^SL2K4_TOP">
 				<Link VarA="PlcTask Inputs^Main.M25.Axis.NcToPlc" VarB="Outputs^ToPlc"/>
 				<Link VarA="PlcTask Outputs^Main.M25.Axis.PlcToNc" VarB="Inputs^FromPlc"/>
-				<Link VarA="PlcTask Outputs^Main.M25_position_UDINT" VarB="Enc^Inputs^In^nDataIn1" AutoLink="true"/>
+				<Link VarA="PlcTask Outputs^Main.nM25Position" VarB="Enc^Inputs^In^nDataIn1" AutoLink="true"/>
 			</OwnerB>
 		</OwnerA>
 	</Mappings>

--- a/lcls-plc-tmo-optics/lcls-plc-tmo-optics.tsproj
+++ b/lcls-plc-tmo-optics/lcls-plc-tmo-optics.tsproj
@@ -2,15 +2,16 @@
 <TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.35" TcVersionFixed="true">
 	<Project ProjectGUID="{469D9277-D01A-45EE-A69D-357039FEE32B}" TargetNetId="172.21.92.63.1.1" Target64Bit="true" RelativeTargetNetId="true" RelativeIpAddresses="true" ShowHideConfigurations="#x306">
 		<System>
-			<Licenses CacheOrCheckLicensesOnStartup="true">
+			<Licenses IgnoreProjectLicenses="true" CacheOrCheckLicensesOnStartup="true">
 				<Target BkhfOrder="01451158">
+					<ManualSelect>{3FF18E97-7754-401B-93FB-70544DE28A13}</ManualSelect>
+					<ManualSelect>{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</ManualSelect>
+					<ManualSelect>{66689887-CCBD-452C-AC9A-039D997C6E66}</ManualSelect>
 					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
-					<TargetSelect TargetId="2">{BF78CFC7-2E63-42C3-8C07-BB6C346BFB8B}</TargetSelect>
-					<TargetSelect TargetId="2">{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</TargetSelect>
-					<TargetSelect TargetId="2">{66689887-CCBD-452C-AC9A-039D997C6E66}</TargetSelect>
+					<ManualSelect>{777F1598-583B-4503-99BB-7C02E0ABD97E}</ManualSelect>
+					<ManualSelect>{4C256767-E6E6-4AF5-BD68-9F7ABAD0C200}</ManualSelect>
+					<ManualSelect>{520DE751-9DB6-47CB-8240-BD5C466E7E64}</ManualSelect>
 					<TargetSelect TargetId="2">{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</TargetSelect>
-					<TargetSelect TargetId="2">{777F1598-583B-4503-99BB-7C02E0ABD97E}</TargetSelect>
-					<TargetSelect TargetId="2">{520DE751-9DB6-47CB-8240-BD5C466E7E64}</TargetSelect>
 					<LicenseDevice DongleHardwareId="2" DongleDevice="#x03020003" DongleLevel="50" DongleSystemId="{1D80F7C2-31ED-9281-AA5C-29E3F1BB5960}" DongleSerialNumber="0100061368"/>
 				</Target>
 			</Licenses>

--- a/lcls-plc-tmo-optics/tmo_optics/tmo_optics.tmc
+++ b/lcls-plc-tmo-optics/tmo_optics/tmo_optics.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{9C838E67-D00C-0196-A25B-A6024E89C10D}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{3DF987F6-C15A-5B4B-4870-3DE72CC53B1C}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="Tc2_SerialCom">ComSerialLineMode_t</Name>
@@ -83320,7 +83320,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitOffs>650445632</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.M25_position_UDINT</Name>
+            <Name>Main.nM25Position</Name>
             <BitSize>32</BitSize>
             <BaseType>UDINT</BaseType>
             <Properties>
@@ -83336,7 +83336,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitOffs>650771456</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.M26_position_UDINT</Name>
+            <Name>Main.nM26Position</Name>
             <BitSize>32</BitSize>
             <BaseType>UDINT</BaseType>
             <Properties>
@@ -83352,7 +83352,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitOffs>650771488</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.M27_position_UDINT</Name>
+            <Name>Main.nM27Position</Name>
             <BitSize>32</BitSize>
             <BaseType>UDINT</BaseType>
             <Properties>
@@ -83368,7 +83368,7 @@ The BPTM will throw an error if the arbiter does not have enough space for the t
             <BitOffs>650771520</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Main.M28_position_UDINT</Name>
+            <Name>Main.nM28Position</Name>
             <BitSize>32</BitSize>
             <BaseType>UDINT</BaseType>
             <Properties>
@@ -95117,7 +95117,7 @@ Silicon surface: RBV &lt;= 4820000: 0000_0000_0001_1110 (allow everything betwee
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2025-02-25T14:38:01</Value>
+          <Value>2025-04-29T15:53:14</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-plc-tmo-optics_scope/VSSettings/.vsm
+++ b/lcls-plc-tmo-optics_scope/VSSettings/.vsm
@@ -6,7 +6,7 @@
     <Node>
       <Title>Scope YT NC Project</Title>
       <Expanded>False</Expanded>
-      <FileName>C:\Users\baljamal\work\lcls-plc-tmo-optics\lcls-plc-tmo-optics_scope\Scope YT NC Project.tcscopex</FileName>
+      <FileName>C:\Users\tongju\github-repo\tmo\lcls-plc-tmo-optics\lcls-plc-tmo-optics_scope\Scope YT NC Project.tcscopex</FileName>
       <Children>
         <Node>
           <Title>DataPool</Title>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## optics PLC is crashing showing TF5020 license missing
<!--- Describe your changes in detail -->
Disable automatically finding licenses. Manually add TF5000 and TF6310 which support 35 axes total. It works after that. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
license TF5020 should not pop out automatically. Current license supports enough axes for TMO optics. 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
move MR2K4 and it works
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
(https://jira.slac.stanford.edu/browse/ECS-7818)
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
