### PR TITLE
turn off mr4k4-x and mr5k4-y plc limits

### DIFF
--- a/lcls-plc-tmo-optics/_Config/NC/NC.xti
+++ b/lcls-plc-tmo-optics/_Config/NC/NC.xti
@@ -1362,8 +1362,8 @@ External Setpoint Generation:
 			</AxisPara>
 			<Encoder Name="Enc" EncType="29">
 				<EncPara ScaleFactorNumerator="5e-06" Offset="-28.961399" MaxCount="#xffffffff">
-					<SoftEndMinControl Enable="true" Range="-11.2"/>
-					<SoftEndMaxControl Enable="true" Range="13.2"/>
+					<SoftEndMinControl Range="-11.2"/>
+					<SoftEndMaxControl Range="13.2"/>
 					<Inc RefSoftSyncMask="#x0000ffff"/>
 				</EncPara>
 				<Vars VarGrpType="1">
@@ -2064,8 +2064,8 @@ External Setpoint Generation:
 			</AxisPara>
 			<Encoder Name="Enc" EncType="29">
 				<EncPara ScaleFactorNumerator="5e-06" Offset="-29.7766" MaxCount="#xffffffff">
-					<SoftEndMinControl Enable="true" Range="-12.3"/>
-					<SoftEndMaxControl Enable="true" Range="12.33"/>
+					<SoftEndMinControl Range="-12.3"/>
+					<SoftEndMaxControl Range="12.33"/>
 					<Inc RefSoftSyncMask="#x0000ffff"/>
 				</EncPara>
 				<Vars VarGrpType="1">

--- a/lcls-plc-tmo-optics/lcls-plc-tmo-optics.tsproj
+++ b/lcls-plc-tmo-optics/lcls-plc-tmo-optics.tsproj
@@ -5,8 +5,8 @@
 			<Licenses IgnoreProjectLicenses="true" CacheOrCheckLicensesOnStartup="true">
 				<Target BkhfOrder="01451158">
 					<ManualSelect>{3FF18E97-7754-401B-93FB-70544DE28A13}</ManualSelect>
-					<ManualSelect>{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</ManualSelect>
 					<ManualSelect>{66689887-CCBD-452C-AC9A-039D997C6E66}</ManualSelect>
+					<ManualSelect>{BCA6EE0A-9CE1-4D3F-98CA-413ABC0D94FD}</ManualSelect>
 					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
 					<ManualSelect>{777F1598-583B-4503-99BB-7C02E0ABD97E}</ManualSelect>
 					<ManualSelect>{4C256767-E6E6-4AF5-BD68-9F7ABAD0C200}</ManualSelect>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Before dream commission, James asks to turn off mr4k4-x and mr5k4-y plc soft limits.
After the first three night shifts, James want to keep it open for them to do more commission in July.
I will push PR here and merge, so that other people will not have any mismatch issues in optics PLC.
<!--- Describe your changes in detail -->
Turn off mr4k4-x and mr5k4-y PLC limits
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Scientists ask for this to give them freedom during shift
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
